### PR TITLE
feat: configure ArgoCD Application finalizers and source.plugin

### DIFF
--- a/internal/myks/assets/data-schema.ytt.yaml
+++ b/internal/myks/assets/data-schema.ytt.yaml
@@ -17,6 +17,10 @@ argocd:
     name: ""
     #! Prefix of the ArgoCD application name.
     prefix: ""
+    #! List of finalizers of the ArgoCD application.
+    #! See https://github.com/argoproj/argo-cd/blob/dc8d729078df6fe9d4c480df0e67b2402af75e0b/docs/user-guide/app_deletion.md
+    #@schema/default ["resources-finalizer.argocd.argoproj.io"]
+    finalizers: [""]
     destination:
       #! spec.destination.name of the ArgoCD application.
       #! If not set, defaults to the name of the current environment.
@@ -32,6 +36,9 @@ argocd:
       #! If not set, defaults to the destination path of the currently rendered application.
       #! With the default myks configuration: `rendered/envs/<environment.id>/<app.name>`
       path: ""
+      #! spec.source.plugin of the ArgoCD application.
+      #@schema/type any=True
+      plugin: {}
       #! spec.source.repoURL of the ArgoCD application.
       #! If not set, defaults to the current git repository URL.
       repoURL: ""

--- a/internal/myks/templates/argocd/application.ytt.yaml
+++ b/internal/myks/templates/argocd/application.ytt.yaml
@@ -13,6 +13,7 @@ kind: Application
 metadata:
   name: #@ app_name
   namespace: #@ a.namespace
+  finalizers: #@ a.app.finalizers or []
 spec:
   project: #@ project_name
   destination:
@@ -24,6 +25,7 @@ spec:
     namespace: #@ a.app.destination.namespace or a.app.name
   source:
     path: #@ a.app.source.path
+    plugin: #@ a.app.source.plugin
     repoURL: #@ a.app.source.repoURL
     targetRevision: #@ a.app.source.targetRevision
   syncPolicy:


### PR DESCRIPTION
This allows a user to define ArgoCD Application finalizers and a custom plugin via data values instead of overlays.