### PR TITLE
refactor: vendir config

### DIFF
--- a/internal/myks/application.go
+++ b/internal/myks/application.go
@@ -29,7 +29,7 @@ type Application struct {
 	e *Environment
 
 	argoCDEnabled bool
-	cached        bool
+	useCache      bool
 	yttDataFiles  []string
 	yttPkgDirs    []string
 }
@@ -86,19 +86,18 @@ func (a *Application) Init() error {
 	type ArgoCD struct {
 		Enabled bool `yaml:"enabled"`
 	}
-	type Cache struct {
-		Enabled bool `yaml:"enabled"`
-	}
 	type YttPkg struct {
 		Dirs []string `yaml:"dirs"`
 	}
 
 	var applicationData struct {
 		Application struct {
-			Cache  Cache  `yaml:"cache"`
 			YttPkg YttPkg `yaml:"yttPkg"`
 		}
 		ArgoCD ArgoCD `yaml:"argocd"`
+		Sync   struct {
+			UseCache bool `yaml:"useCache"`
+		} `yaml:"sync"`
 	}
 
 	err = yaml.Unmarshal(dataYaml, &applicationData)
@@ -106,7 +105,7 @@ func (a *Application) Init() error {
 		return err
 	}
 	a.argoCDEnabled = applicationData.ArgoCD.Enabled
-	a.cached = applicationData.Application.Cache.Enabled
+	a.useCache = applicationData.Sync.UseCache
 	a.yttPkgDirs = applicationData.Application.YttPkg.Dirs
 
 	return nil

--- a/internal/myks/assets/data-schema.ytt.yaml
+++ b/internal/myks/assets/data-schema.ytt.yaml
@@ -1,8 +1,11 @@
 #! This file define a schema for all ytt data files. It can also contain default values.
 #! Top-level keys are scopes, e.g. application, argocd, environment, helm.
+#!
 #! Content of the `application` scope can be freely modified. More scopes can be added.
-#! The `environment`, `helm` and `argocd` scopes are used by myks and should not be modified.
-#! However, more keys can be added to these scopes.
+#!
+#! All other scopes and their keys defined in this file are used by myks.
+#! Values of these keys can be modified, but the keys should not be removed.
+#! It is fine, however, to add new keys to these scopes.
 
 #@data/values-schema
 ---

--- a/internal/myks/assets/data-schema.ytt.yaml
+++ b/internal/myks/assets/data-schema.ytt.yaml
@@ -68,33 +68,28 @@ environment:
   #@schema/validation min_len=1
   #@schema/nullable
   id: ""
-  #! List of applications to be deployed in the environment, required by myks.
+  #! List of applications to be deployed in the environment.
   applications:
-    - #! Prototype of the application, required by myks.
+    - #! Prototype of the application.
       #@schema/validation min_len=1
       proto: ""
-      #! Name of the application, used by myks. If not defined, the name of the prototype is used.
+      #! Name of the application. If not defined, the name of the prototype is used.
       name: ""
 #! Configuration of the step that renders Helm charts.
 helm:
-  #! Used by myks.
   #! If defined, passed as `--api-version` for `helm-template`.
   capabilities:
     - "" #! e.g. "monitoring.coreos.com/v1"
-  #! Used by myks.
   #! If true, adds `--include-crds` flag to `helm template`.
   includeCRDs: true
-  #! Used by myks.
   #! If defined, passed as a value of `--kube-version` for `helm template`.
   kubeVersion: ""
-  #! Used by myks.
   #! If defined, passed as a value of `--namespace` for `helm template`.
   namespace: ""
 #! Myks configuration and runtime data.
+#! Default values for these options are set by myks.
 myks:
-  #! Set by myks.
   #! Set to the current git branch if available.
   gitRepoBranch: ""
-  #! Set by myks.
   #! Set to the current git repository URL if available.
   gitRepoUrl: ""

--- a/internal/myks/assets/data-schema.ytt.yaml
+++ b/internal/myks/assets/data-schema.ytt.yaml
@@ -86,6 +86,14 @@ helm:
   kubeVersion: ""
   #! If defined, passed as a value of `--namespace` for `helm template`.
   namespace: ""
+#! Configuration options for the sync step.
+sync:
+  #! If true, the sync step is performed only if the vendir.yaml file is changed after the previous sync.
+  #! Decision whether to sync or not is done on a per-directory basis. This allows to completely skip running
+  #! `vendir sync` for directories that are not changed.
+  #! /!\ Be careful when using this option with dynamic versions (e.g. `latest`, or a branch name).
+  #!     If the upstream is updated, but the vendir config is not changed, the sync step will not be performed.
+  useCache: true
 #! Myks configuration and runtime data.
 #! Default values for these options are set by myks.
 myks:

--- a/internal/myks/render_test.go
+++ b/internal/myks/render_test.go
@@ -16,7 +16,7 @@ var testApp = &Application{
 		Dir: "/tmp",
 	},
 	yttDataFiles: nil,
-	cached:       false,
+	useCache:     false,
 	yttPkgDirs:   nil,
 }
 

--- a/internal/myks/sync.go
+++ b/internal/myks/sync.go
@@ -116,7 +116,7 @@ func (a *Application) doSync(vendirSecrets string) error {
 
 	// TODO sync retry
 	// only sync vendir with directory flag, if the lock file matches the vendir config file and caching is enabled
-	if a.cached && checkLockFileMatch(vendirDirs, lockFileDirs) {
+	if a.useCache && checkLockFileMatch(vendirDirs, lockFileDirs) {
 		for _, dir := range vendirDirs {
 			if checkVersionMatch(dir.Path, dir.ContentHash, syncFileDirs) {
 				log.Info().Msg(a.Msg(syncStepName, "Resource already synced"))


### PR DESCRIPTION
- Changed `data-schema` comments to be more informative and less redundant.
- Moved sync cache config from the `application` scope within `data-schema` to its own `sync` scope.
- Renamed keys for simplicity (`cached` → `useCache`, `cache.enabled` → `useCache`).