### PR TITLE
fix: reduce usage of pointers to cope with race conditions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mykso/myks
 
-go 1.20
+go 1.21
 
 require (
 	github.com/alecthomas/chroma v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,7 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -107,6 +108,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -139,9 +141,11 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/logrusorgru/aurora/v4 v4.0.0 h1:sRjfPpun/63iADiSvGGjgA1cAYegEWMPCJdUpJYn9JA=
 github.com/logrusorgru/aurora/v4 v4.0.0/go.mod h1:lP0iIa2nrnT/qoFXcOZSrZQpJ1o6n2CUf/hyHi2Q4ZQ=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -162,6 +166,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.29.1 h1:cO+d60CHkknCbvzEWxP0S9K6KqyTjrCNUy1LdQLCGPc=
 github.com/rs/zerolog v1.29.1/go.mod h1:Le6ESbR7hc+DP6Lt1THiV8CQSdkkNrd3R0XbEgp3ZBU=

--- a/internal/myks/application.go
+++ b/internal/myks/application.go
@@ -75,7 +75,7 @@ func (a *Application) Init() error {
 
 	a.collectDataFiles()
 
-	dataYaml, err := a.renderDataYaml(append(a.e.g.extraYttPaths, a.yttDataFiles...))
+	dataYaml, err := a.renderDataYaml(concatenate(a.e.g.extraYttPaths, a.yttDataFiles))
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func (a *Application) ytt(step, purpose string, paths []string, args ...string) 
 }
 
 func (a *Application) yttS(step string, purpose string, paths []string, stdin io.Reader, args ...string) (CmdResult, error) {
-	paths = append(a.e.g.extraYttPaths, paths...)
+	paths = concatenate(a.e.g.extraYttPaths, paths)
 	return runYttWithFilesAndStdin(paths, stdin, func(name string, args []string) {
 		log.Debug().Msg(a.Msg(step, msgRunCmd(purpose, name, args)))
 	}, args...)

--- a/internal/myks/application.go
+++ b/internal/myks/application.go
@@ -146,9 +146,9 @@ func (a *Application) Msg(step string, msg string) string {
 	return formattedMessage
 }
 
-func (a *Application) runCmd(purpose string, cmd string, stdin io.Reader, args []string) (CmdResult, error) {
+func (a *Application) runCmd(step, purpose, cmd string, stdin io.Reader, args []string) (CmdResult, error) {
 	return runCmd(cmd, stdin, args, func(cmd string, args []string) {
-		log.Debug().Msg(msgRunCmd(purpose, cmd, args))
+		log.Debug().Msg(a.Msg(step, msgRunCmd(purpose, cmd, args)))
 	})
 }
 
@@ -177,7 +177,7 @@ func (a *Application) mergeValuesYaml(valueFilesYaml string) (CmdResult, error) 
 	}, "--data-values-file="+valueFilesYaml, "--data-values-inspect")
 }
 
-func (a *Application) ytt(step string, purpose string, paths []string, args ...string) (CmdResult, error) {
+func (a *Application) ytt(step, purpose string, paths []string, args ...string) (CmdResult, error) {
 	return a.yttS(step, purpose, paths, nil, args...)
 }
 

--- a/internal/myks/application.go
+++ b/internal/myks/application.go
@@ -53,21 +53,18 @@ func NewApplication(e *Environment, name string, prototypeName string) (*Applica
 
 	prototype := filepath.Join(e.g.PrototypesDir, prototypeName)
 
-	if _, err := os.Stat(prototype); err != nil {
-		return nil, errors.New("application prototype does not exist")
-	}
-
 	app := &Application{
 		Name:      name,
 		Prototype: prototype,
 		e:         e,
 	}
-	err := app.Init()
-	if err != nil {
-		return nil, err
+
+	if _, err := os.Stat(prototype); err != nil {
+		return app, errors.New("application prototype does not exist")
 	}
 
-	return app, nil
+	err := app.Init()
+	return app, err
 }
 
 func (a *Application) Init() error {

--- a/internal/myks/environment.go
+++ b/internal/myks/environment.go
@@ -313,7 +313,7 @@ func (e *Environment) ytt(purpose string, paths []string, args ...string) (CmdRe
 }
 
 func (e *Environment) yttS(purpose string, paths []string, stdin io.Reader, args ...string) (CmdResult, error) {
-	paths = append(e.g.extraYttPaths, paths...)
+	paths = concatenate(e.g.extraYttPaths, paths)
 	return runYttWithFilesAndStdin(paths, stdin, func(name string, args []string) {
 		log.Debug().Msg(e.Msg(msgRunCmd(purpose, name, args)))
 	}, args...)

--- a/internal/myks/environment.go
+++ b/internal/myks/environment.go
@@ -34,7 +34,7 @@ type Environment struct {
 	foundApplications map[string]string
 }
 
-func NewEnvironment(g *Globe, dir string) *Environment {
+func NewEnvironment(g *Globe, dir string) (*Environment, error) {
 	envDataFile := filepath.Join(dir, g.EnvironmentDataFileName)
 
 	env := &Environment{
@@ -48,11 +48,8 @@ func NewEnvironment(g *Globe, dir string) *Environment {
 
 	// Read an environment id from an environment data file.
 	// The environment data file must exist and contain an .environment.id field.
-	if err := env.setId(); err != nil {
-		return nil
-	}
-
-	return env
+	err := env.setId()
+	return env, err
 }
 
 func (e *Environment) Init(applicationNames []string) error {

--- a/internal/myks/globe.go
+++ b/internal/myks/globe.go
@@ -399,11 +399,14 @@ func (g *Globe) collectEnvironmentsInPath(searchPath string) {
 		if d != nil && d.IsDir() {
 			_, err := os.Stat(filepath.Join(path, g.EnvironmentDataFileName))
 			if err == nil {
-				env := NewEnvironment(g, path)
-				if env != nil {
+				env, err := NewEnvironment(g, path)
+				if err == nil {
 					g.environments[path] = env
 				} else {
-					log.Debug().Str("path", path).Msg("Unable to collect environment, might be base or parent environment. Skipping")
+					log.Debug().
+						Err(err).
+						Str("path", path).
+						Msg("Unable to collect environment, might be base or parent environment. Skipping")
 				}
 			}
 		}

--- a/internal/myks/render.go
+++ b/internal/myks/render.go
@@ -179,7 +179,7 @@ func (a *Application) prepareValuesFile(dirName string, resourceName string) (st
 		return "", nil
 	}
 
-	resourceValuesYaml, err := a.ytt(renderStepName, "collect data values file", append(a.yttDataFiles, valuesFiles...))
+	resourceValuesYaml, err := a.ytt(renderStepName, "collect data values file", concatenate(a.yttDataFiles, valuesFiles))
 	if err != nil {
 		log.Warn().Err(err).Msg(a.Msg(renderStepName, "Unable to render resource values templates"))
 		return "", err

--- a/internal/myks/render_helm.go
+++ b/internal/myks/render_helm.go
@@ -92,7 +92,7 @@ func (h *Helm) Render(_ string) (string, error) {
 			helmArgs = append(helmArgs, "--values", helmValuesFile)
 		}
 
-		res, err := h.app.runCmd("helm template chart", "helm", nil, append(helmArgs, commonHelmArgs...))
+		res, err := h.app.runCmd(helmStepName, "helm template chart", "helm", nil, append(helmArgs, commonHelmArgs...))
 		if err != nil {
 			log.Error().Msg(h.app.Msg(helmStepName, res.Stderr))
 			return "", err

--- a/internal/myks/sync.go
+++ b/internal/myks/sync.go
@@ -50,8 +50,7 @@ func (a *Application) prepareSync() error {
 	yttFiles = append(yttFiles, appVendirDirs...)
 
 	if len(yttFiles) == 0 {
-		err := ErrNoVendirConfig
-		return err
+		return ErrNoVendirConfig
 	}
 
 	vendirConfig, err := a.ytt(syncStepName, "creating vendir config", yttFiles)

--- a/internal/myks/sync.go
+++ b/internal/myks/sync.go
@@ -154,7 +154,7 @@ func (a *Application) runVendirSync(targetDir string, vendirConfig string, vendi
 	if directory != "" {
 		args = append(args, "--directory="+directory)
 	}
-	res, err := a.runCmd("vendir sync", "vendir", strings.NewReader(vendirSecrets), args)
+	res, err := a.runCmd(syncStepName, "vendir sync", "vendir", strings.NewReader(vendirSecrets), args)
 	if err != nil {
 		log.Error().Err(err).Str("stdout", res.Stdout).Str("stderr", res.Stderr).Msg(a.Msg(syncStepName, "Unable to sync vendir"))
 		return err

--- a/internal/myks/util.go
+++ b/internal/myks/util.go
@@ -272,7 +272,7 @@ func msgRunCmd(purpose string, cmd string, args []string) string {
 	return "Running \u001B[34m" + cmd + "\u001B[0m to: \u001B[3m" + purpose + "\u001B[0m\n\u001B[37m" + msg + "\u001B[0m"
 }
 
-func runYttWithFilesAndStdin(paths []string, stdin io.Reader, log func(name string, args []string), args ...string) (CmdResult, error) {
+func runYttWithFilesAndStdin(paths []string, stdin io.Reader, logFn func(name string, args []string), args ...string) (CmdResult, error) {
 	if stdin != nil {
 		paths = append(paths, "-")
 	}
@@ -283,7 +283,7 @@ func runYttWithFilesAndStdin(paths []string, stdin io.Reader, log func(name stri
 	}
 
 	cmdArgs = append(cmdArgs, args...)
-	return runCmd("ytt", stdin, cmdArgs, log)
+	return runCmd("ytt", stdin, cmdArgs, logFn)
 }
 
 func extract[T any](items []T, filterFunc func(cf T) bool) []T {

--- a/internal/myks/util.go
+++ b/internal/myks/util.go
@@ -295,3 +295,12 @@ func extract[T any](items []T, filterFunc func(cf T) bool) []T {
 	}
 	return result
 }
+
+// Concatenates multiple slices of the same type together creating a new underlying array
+func concatenate[T any](slices ...[]T) []T {
+	result := []T{}
+	for _, slice := range slices {
+		result = append(result, slice...)
+	}
+	return result
+}


### PR DESCRIPTION
At least one occurrence of race conditions was observed: when running `myks sync` for a number of applications, generated `vendir.yaml` files get mixed up. The following lines of logs demonstrate the issue:

```
3:15PM DBG [phoenix-platform-production > httpbingo > sync] Running ytt to: creating vendir config
ytt --file=lib --file=.myks/tmp/data-schema.ytt.yaml --file=.myks/tmp/myks-data.ytt.yaml --file=prototypes/monitoring/vendir
```

Notice that this log output is printed for the `httpbingo` application, but the `ytt` command gets `--file=prototypes/monitoring/vendir` as one of the arguments.

This happens in this function: https://github.com/mykso/myks/blob/215ccd3f51231c20a07c92350eb7d0379dfd0784/internal/myks/util.go#L275-L287

~Somehow the `paths` value is changed outside. Sometimes it might be correct at the beginning of the function but wrong some lines later. Sometimes it is wrong at the beginning, but correct in the caller function.~

~I didn't understand the exact mechanism behind this issue, but I was able to reproduce it. Switching from pointers to normal values solves the problem.~

I figured that out. It was the golang's mechanism of reusing an underlying array via slices. In this particular case, the `append` function was just overwriting the last element of the underlying array of the `a.e.g.extraYttPaths` slice instead of creating a new one.

https://github.com/mykso/myks/blob/215ccd3f51231c20a07c92350eb7d0379dfd0784/internal/myks/application.go#L184-L189