### PR TITLE
feat: support multiple content items in vendir configs

### DIFF
--- a/SMARTMODE.md
+++ b/SMARTMODE.md
@@ -14,21 +14,25 @@ will exit immediately, before any syncing or rendering happens.
 ### Re-rendering of an application
 
 An application of a specific environment get re-rendered when:
+
 - The `app-data.ytt.yaml` of that application has changed, e.g. `envs/env-1/_apps/app-1/app-data.ytt.yaml`
-- The prototype application has changed, e.g. `prototypes/app-1/helm/app-1.yaml`, in which case all environments that use is re-render that application.
+- The prototype application has changed, e.g. `prototypes/app-1/helm/app-1.yaml`, in which case all environments that
+  use is re-render that application.
 
 ### Re-rendering of an environment
 
 All applications of an environment get re-rendered when:
+
 - The `env-data.ytt.yaml` of that environment has changed.
 - The `env-data.ytt.yaml` of a parent environment of that environment has changed.
-- **Edge case:** If you have made changes to an application in env-1, but at the same time have modified the `env-data.ytt.yaml` of env-2, smart-mode will re-render all applications of env-1 AND env-2, even though this is not strictly required for env-1.
+- **Edge case:** If you have made changes to an application in env-1, but at the same time have modified the
+  `env-data.ytt.yaml` of env-2, smart-mode will re-render all applications of env-1 AND env-2, even though this is not
+  strictly required for env-1.
 
 ### Complete rendering
 
 A complete rendering of all environments and all applications is required when:
+
 - A file in the common lib has changed, e.g. `/lib/common.lib.star`
 - A file in the global ytt folder has changed, e.g. `/envs/_env/ytt/annotate_crds.yaml`
 - The base `env-data.ytt.yaml` has changed: `/envs/env-data.ytt.yaml`
-
-

--- a/internal/myks/sync.go
+++ b/internal/myks/sync.go
@@ -84,8 +84,8 @@ func (a *Application) doSync(vendirSecrets string) error {
 	// Paths are relative to the vendor directory (BUG: this will brake with multi-level vendor directory, e.g. `vendor/shmendor`)
 	vendirConfigFileRelativePath := filepath.Join("..", a.e.g.ServiceDirName, a.e.g.VendirConfigFileName)
 	vendirLockFileRelativePath := filepath.Join("..", a.e.g.ServiceDirName, a.e.g.VendirLockFileName)
-	vendirConfigFilePath := filepath.Join(a.expandServicePath(""), a.e.g.VendirConfigFileName)
-	vendirLockFilePath := filepath.Join(a.expandServicePath(""), a.e.g.VendirLockFileName)
+	vendirConfigFilePath := a.expandServicePath(a.e.g.VendirConfigFileName)
+	vendirLockFilePath := a.expandServicePath(a.e.g.VendirLockFileName)
 	vendirSyncFilePath := a.expandServicePath(a.e.g.VendirSyncFileName)
 	vendorDir := a.expandPath(a.e.g.VendorDirName)
 

--- a/internal/myks/sync.go
+++ b/internal/myks/sync.go
@@ -225,12 +225,17 @@ func getVendirDirHashes(config map[string]interface{}) (vendirDirHashes, error) 
 	for _, dir := range config["directories"].([]interface{}) {
 		dirMap := dir.(map[string]interface{})
 		path := dirMap["path"].(string)
+		contents := dirMap["contents"].([]interface{})
+		for _, content := range contents {
+			contentMap := content.(map[string]interface{})
+			contentPath := contentMap["path"].(string)
+			sortedYaml, err := sortYaml(contentMap)
+			if err != nil {
+				return nil, err
+			}
 
-		sortedYaml, err := sortYaml(dirMap)
-		if err != nil {
-			return nil, err
+			dirHashes[filepath.Join(path, contentPath)] = hashString(sortedYaml)
 		}
-		dirHashes[path] = hashString(sortedYaml)
 	}
 	return dirHashes, nil
 }

--- a/internal/myks/sync.go
+++ b/internal/myks/sync.go
@@ -86,7 +86,7 @@ func (a *Application) doSync(vendirSecrets string) error {
 	vendirLockFileRelativePath := filepath.Join("..", a.e.g.ServiceDirName, a.e.g.VendirLockFileName)
 	vendirConfigFilePath := filepath.Join(a.expandServicePath(""), a.e.g.VendirConfigFileName)
 	vendirLockFilePath := filepath.Join(a.expandServicePath(""), a.e.g.VendirLockFileName)
-	vendirSyncFilePath := a.expandTempPath(a.e.g.VendirSyncFileName)
+	vendirSyncFilePath := a.expandServicePath(a.e.g.VendirSyncFileName)
 	vendorDir := a.expandPath(a.e.g.VendorDirName)
 
 	vendirDirs, err := readVendirConfig(vendirConfigFilePath)
@@ -137,7 +137,7 @@ func (a *Application) doSync(vendirSecrets string) error {
 		}
 	}
 
-	err = writeSyncFile(a.expandTempPath(a.e.g.VendirSyncFileName), vendirDirs)
+	err = writeSyncFile(a.expandServicePath(a.e.g.VendirSyncFileName), vendirDirs)
 	if err != nil {
 		log.Error().Err(err).Msg(a.Msg(syncStepName, "Unable to write sync file"))
 		return err
@@ -235,6 +235,7 @@ func findDirectories(config map[string]interface{}) ([]Directory, error) {
 	if _, ok := config["directories"]; !ok {
 		return nil, errors.New("no directories found in vendir config")
 	}
+
 	var syncDirs []Directory
 
 	for _, dir := range config["directories"].([]interface{}) {

--- a/internal/myks/sync_test.go
+++ b/internal/myks/sync_test.go
@@ -72,21 +72,21 @@ func Test_getVendirDirHashes(t *testing.T) {
 		{
 			"happy path",
 			"../../testData/sync/vendir-simple.yaml",
-			vendirDirHashes{"vendor/charts/loki-stack": "da992fbae34fe2c310026bef76eb03cf103743010c98a8a1922303a384833fdd"},
+			vendirDirHashes{"vendor/charts/loki-stack": "6fc0b0703de83385531372f85eae1763ae6af7068ec0b420abd5562adec2a01f"},
 			false,
 		},
 		{
 			"yaml order irrelevant for hash",
 			"../../testData/sync/vendir-simple-different-order.yaml",
-			vendirDirHashes{"vendor/charts/loki-stack": "64eb3e3e2af99bc1d5fd155b2edc4ed3b4721430919602cd6d11c76d3ab17d24"},
+			vendirDirHashes{"vendor/charts/loki-stack": "5589fa11a8117eefbec30e4190b9649dd282bd747b4acbd6e47201700990870b"},
 			false,
 		},
 		{
 			"multiple directories",
 			"../../testData/sync/vendir-multiple-directories.yaml",
 			vendirDirHashes{
-				"vendor/charts/ingress-nginx":   "3b52aa63642d9d9ab4bb3007ce67f1f0431d1791c4d4c78a544971d67728320a",
-				"vendor/ytt/grafana-dashboards": "c068fe6a6572bf9fc0aeb87f70acd494122931b44ea4297a1297fb2f735b2723",
+				"vendor/charts/ingress-nginx":   "84bc14f63b966dcec26278cc66976cdba19a8757f5b06f2be463e8033c8ade9c",
+				"vendor/ytt/grafana-dashboards": "4f95153c2130e5967fc97f0977877012b3f1579e6fcd9e66184302252ca83c70",
 			},
 			false,
 		},
@@ -99,13 +99,16 @@ func Test_getVendirDirHashes(t *testing.T) {
 		{
 			"multiple contents",
 			"../../testData/sync/vendir-multiple-contents.yaml",
-			vendirDirHashes{"vendor/charts/ingress-nginx": "e9b262400008526b84cf46d99f844f84bbbef2abedc38a077ef7c6ec015ef6dd"},
+			vendirDirHashes{
+				"vendor/charts/ingress-nginx/chart":      "38e595e0991357e484d8bdaf92c53d9b4d97c62d063222882fbb00f1732a7523",
+				"vendor/charts/ingress-nginx/dashboards": "8dd23a97c0b896d94789d96afe1c278f7287d1580b9a58f5a6087fa44e684b46",
+			},
 			false,
 		},
 		{
 			"with sub path",
 			"../../testData/sync/vendir-with-subpath.yaml",
-			vendirDirHashes{"vendor/charts": "92f1735562d38c44a735022f1ada170b7d286ef2e51f9cba9a3c67c83c9ecae0"},
+			vendirDirHashes{"vendor/charts/loki-stack": "5fa245cedee795a9a01fc62f3c56ac809dc8b304f6656897d060b68b8a5f32ef"},
 			false,
 		},
 	}
@@ -137,8 +140,8 @@ func Test_readLockFile(t *testing.T) {
 		wantErr bool
 	}{
 		{"happy path", args{"../../testData/sync/lock-file.yaml"}, vendirDirHashes{
-			"vendor/charts":               "98d8127a386c0e1520c758783642a42d7cee97b32a8f255974ea3d48bc237f5a",
-			"vendor/charts/ingress-nginx": "3eec412b32018cdad77f2b084719a142f034bb9df19866f0cf847641a4c27a96",
+			"vendor/charts/loki-stack":    "9ebaa03dc8dd419b94a124193f6b597037daa95e208febb0122ca8920667f42a",
+			"vendor/charts/ingress-nginx": "1d535ff265861947e32c890cbcb76d93a9562771dbd7b3367e4d723c1c6d95db",
 		}, false},
 		{"file not exist", args{"file-not-exist.yaml"}, vendirDirHashes{}, false},
 		{"no lock file", args{"../../testData/sync/simple.yaml"}, nil, true},
@@ -191,13 +194,13 @@ func Test_readVendirConfig(t *testing.T) {
 		{
 			"happy path",
 			args{"../../testData/sync/vendir-simple.yaml"},
-			vendirDirHashes{"vendor/charts/loki-stack": "da992fbae34fe2c310026bef76eb03cf103743010c98a8a1922303a384833fdd"},
+			vendirDirHashes{"vendor/charts/loki-stack": "6fc0b0703de83385531372f85eae1763ae6af7068ec0b420abd5562adec2a01f"},
 			false,
 		},
 		{
 			"oci image",
 			args{"../../testData/sync/vendir-oci.yaml"},
-			vendirDirHashes{"vendor/ytt/grafana": "cd9f99d5020ad7d19b5fa27919112ace76a2d5c0d948e22207b6cba8d1374f22"},
+			vendirDirHashes{"vendor/ytt/grafana": "11b1e2b989d81bb8daffc10f7be4d059bc0eec684913732fbfdadabbe79c7fb2"},
 			false,
 		},
 		{"file not exist", args{"file-not-exist.yaml"}, nil, true},

--- a/internal/myks/util.go
+++ b/internal/myks/util.go
@@ -186,8 +186,7 @@ func sortYaml(yaml map[string]interface{}) (string, error) {
 	return sorted.String(), nil
 }
 
-// hash string
-func hash(s string) string {
+func hashString(s string) string {
 	hash := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(hash[:])
 }

--- a/internal/myks/util_test.go
+++ b/internal/myks/util_test.go
@@ -24,7 +24,7 @@ func Test_hash(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.a, func(t *testing.T) {
-			if got := hash(tt.b); got != tt.want {
+			if got := hashString(tt.b); got != tt.want {
 				t.Errorf("hash() = %v, wantArgs %v", got, tt.want)
 			}
 		})
@@ -401,14 +401,14 @@ func TestProcess(t *testing.T) {
 
 func assertEqual(t *testing.T, got, want interface{}) {
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Expected:\n%v\nGot:\n%v\nDifference:\n%v", want, got, diff(got, want))
+		t.Errorf("Expected:\n%v\nGot:\n%v\nDifference:\n%v", want, got, diff(want, got))
 	}
 }
 
-func diff(a, b interface{}) string {
+func diff(expected, actual interface{}) string {
 	diff := difflib.UnifiedDiff{
-		A:        difflib.SplitLines(fmt.Sprintf("%v", a)),
-		B:        difflib.SplitLines(fmt.Sprintf("%v", b)),
+		A:        difflib.SplitLines(fmt.Sprintf("%v", expected)),
+		B:        difflib.SplitLines(fmt.Sprintf("%v", actual)),
 		FromFile: "Expected",
 		ToFile:   "Actual",
 		Context:  3,

--- a/testData/sync/sync-file.yaml
+++ b/testData/sync/sync-file.yaml
@@ -1,4 +1,2 @@
-- path: path
-  contentHash: hash
-- path: path2
-  contentHash: hash2
+path: hash
+path2: hash2

--- a/testData/sync/vendir-multiple-contents.yaml
+++ b/testData/sync/vendir-multiple-contents.yaml
@@ -3,7 +3,7 @@ kind: Config
 directories:
   - path: vendor/charts/ingress-nginx
     contents:
-      - path: ingress-nginx
+      - path: chart
         helmChart:
           name: ingress-nginx
           version: 4.7.1


### PR DESCRIPTION
Closes #81 

Apart from that, the code is simplified by throwing away Secrets and using path-to-hash map instead of an array of `Directory` items.