### PR TITLE
fix(sync): trim path separator from vendir directories

### DIFF
--- a/internal/myks/sync.go
+++ b/internal/myks/sync.go
@@ -121,6 +121,7 @@ func (a Application) cleanupVendorDir(vendorDir, vendirConfigFile string) error 
 	for _, dir := range config["directories"].([]interface{}) {
 		dirMap := dir.(map[string]interface{})
 		path := dirMap["path"].(string)
+		path = strings.TrimSuffix(path, string(filepath.Separator))
 		dirs = append(dirs, path+string(filepath.Separator))
 	}
 


### PR DESCRIPTION
When a vendir directory contains a trailing slash, myks is not correctly cleaning up vendor directory.

Fixes #155
