### PR TITLE
fix(plugins): improve logging

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ var (
 
 func NewMyksCmd(version, commit, date string) *cobra.Command {
 	cobra.OnInitialize(initLogger)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	cmd := newRootCmd(version, commit, date)
 	cmd.AddCommand(allCmd)
 	cmd.AddCommand(renderCmd)

--- a/cmd/smart-mode.go
+++ b/cmd/smart-mode.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/logrusorgru/aurora/v4"
-	"github.com/mykso/myks/internal/myks"
+	aurora "github.com/logrusorgru/aurora/v4"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/mykso/myks/internal/myks"
 )
 
 const (

--- a/internal/myks/plugins.go
+++ b/internal/myks/plugins.go
@@ -135,7 +135,7 @@ func (p PluginCmd) Exec(a *Application, args []string) error {
 		} else {
 			log.Info().
 				// writing std out into message to avoid wrapping
-				Msg(a.Msg(step, fmt.Sprintf("Plugin execution succeeded.")))
+				Msg(a.Msg(step, "Plugin execution succeeded."))
 		}
 	}
 	return err

--- a/internal/myks/plugins.go
+++ b/internal/myks/plugins.go
@@ -2,6 +2,7 @@ package myks
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -96,7 +97,7 @@ func (p PluginCmd) Name() string {
 }
 
 func (p PluginCmd) Exec(a *Application, args []string) error {
-	step := "Plugin " + p.Name()
+	step := p.Name()
 	log.Trace().Msg(a.Msg(step, "execution started"))
 
 	env, err := p.generateEnv(a)
@@ -114,16 +115,28 @@ func (p PluginCmd) Exec(a *Application, args []string) error {
 	// log env
 	log.Debug().Msg(a.Msg(step, msgRunCmd("", p.cmd, args)))
 	err = cmd.Run()
+	allOutput := stderrBs.String() + stdoutBs.String()
 	if err != nil {
 		log.Error().Msg(msgRunCmd("Failed on step: "+step, p.cmd, args))
-		log.Error().Err(err).
-			Str("stdout", stdoutBs.String()).
-			// writing std error into message to avoid wrapping
-			Msg(a.Msg(step, "Plugin execution failed: "+stderrBs.String()))
+		if allOutput != "" {
+			log.Error().Err(err).
+				// writing std error into message to avoid wrapping
+				Msg(a.Msg(step, fmt.Sprintf("Plugin execution failed:\n\n%s", allOutput)))
+		} else {
+			log.Error().Err(err).
+				// writing std error into message to avoid wrapping
+				Msg(a.Msg(step, "Plugin execution failed"))
+		}
 	} else {
-		log.Info().
-			// writing std out into message to avoid wrapping
-			Msg(a.Msg(step, "Plugin execution succeeded: "+stdoutBs.String()))
+		if allOutput != "" {
+			log.Info().
+				// writing std out into message to avoid wrapping
+				Msg(a.Msg(step, fmt.Sprintf("Plugin execution succeeded:\n\n%s", allOutput)))
+		} else {
+			log.Info().
+				// writing std out into message to avoid wrapping
+				Msg(a.Msg(step, fmt.Sprintf("Plugin execution succeeded.")))
+		}
 	}
 	return err
 }


### PR DESCRIPTION
Small tweaks to the log output to get a clean log output. Please feast your eyes on my new "apply" plugin output driven by sops, kubeconform and kapp:

```
8:59AM INF [local-kind > my-workload > apply] Plugin execution succeeded:

Decrypting secrets
Validating Kubernetes manifests
Applying Kubernetes manifests
Target cluster 'https://127.0.0.1:45811' (nodes: dev-cluster-control-plane, 2+)

Changes

Namespace  Name  Kind  Age  Op  Op st.  Wait to  Rs  Ri  

Op:      0 create, 0 delete, 0 update, 0 noop, 0 exists
Wait to: 0 reconcile, 0 delete, 0 noop

Succeeded
Encrypting secrets

```

FYI: This is my apply script:
```
#! /usr/bin/env bash

function prepare() {
  local action="$1"
  local exit_code=0
  if [[ -e "$MYKS_RENDERED_APP_DIR"/static ]]; then
    case "$action" in
    "encrypt")
      echo "Encrypting secrets"
      find "$MYKS_RENDERED_APP_DIR"/static -type f -name "*.sops.yaml" -exec sops -e -i {} \;
      exit_code=$?
      ;;
    "decrypt")
      echo "Decrypting secrets"
      find "$MYKS_RENDERED_APP_DIR"/static -type f -name "*.sops.yaml" -exec sops -d -i {} \;
      exit_code=$?
      ;;
    esac
  fi
  if [[ "$exit_code" == 1 ]]; then
    echo "Failed to $action secrets"
  fi
  return $exit_code
}

function validate() {
  echo "Validating Kubernetes manifests"
  kubeconform \
    -schema-location 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{.NormalizedKubernetesVersion}}-standalone{{.StrictSuffix}}/{{.ResourceKind}}{{.KindSuffix}}.json' \
    -strict \
    -skip "CustomResourceDefinition,NetworkAttachmentDefinition" \
    "$MYKS_RENDERED_APP_DIR"
  return $?
}

function apply() {
  echo "Applying Kubernetes manifests"
  set -x
  kapp --wait=false --yes deploy -a "$MYKS_APP" -f "$MYKS_RENDERED_APP_DIR"
  set +x
  return $?
}

main() {
  if ! prepare "decrypt"; then
    exit 1
  fi
  trap "prepare encrypt" EXIT
  if ! validate; then
    echo "Validation failed"
    exit 1
  fi
  if ! apply; then
    echo "Failed to apply manifests"
    exit 1
  fi
}

main


```
