### PR TITLE
feat: Add MYKS_HELM_NAMESPACE to environment passed to plugins

### DIFF
--- a/internal/myks/application.go
+++ b/internal/myks/application.go
@@ -239,3 +239,21 @@ func (a *Application) getHelmChartsDirs(stepName string) ([]string, error) {
 
 	return chartsDirs, nil
 }
+
+func (a *Application) getHelmConfig(step string) (HelmConfig, error) {
+	dataValuesYaml, err := a.ytt(step, "get helm config", a.yttDataFiles, "--data-values-inspect")
+	if err != nil {
+		return HelmConfig{}, err
+	}
+
+	var helmConfig struct {
+		Helm HelmConfig
+	}
+	err = yaml.Unmarshal([]byte(dataValuesYaml.Stdout), &helmConfig)
+	if err != nil {
+		log.Warn().Err(err).Msg(a.Msg(step, "Unable to unmarshal data values"))
+		return HelmConfig{}, err
+	}
+
+	return helmConfig.Helm, nil
+}

--- a/internal/myks/plugins.go
+++ b/internal/myks/plugins.go
@@ -142,12 +142,18 @@ func (p PluginCmd) Exec(a *Application, args []string) error {
 }
 
 func (p PluginCmd) generateEnv(a *Application) (map[string]string, error) {
+	helmConfig, err := a.getHelmConfig("generate-env")
+	if err != nil {
+		return nil, err
+	}
+
 	env := map[string]string{
 		"MYKS_ENV":              a.e.Id,
 		"MYKS_APP":              a.Name,
 		"MYKS_APP_PROTOTYPE":    a.Prototype,
 		"MYKS_ENV_DIR":          a.e.Dir,
 		"MYKS_RENDERED_APP_DIR": a.getDestinationDir(),
+		"MYKS_HELM_NAMESPACE":   helmConfig.Namespace,
 	}
 
 	result, err := a.ytt(p.Name(), "get data values", a.yttDataFiles, "--data-values-inspect")

--- a/internal/myks/render_helm.go
+++ b/internal/myks/render_helm.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog/log"
-	yaml "gopkg.in/yaml.v3"
 )
 
 type Helm struct {
@@ -32,7 +31,7 @@ func (h *Helm) Render(_ string) (string, error) {
 		return "", err
 	}
 
-	helmConfig, err := h.getHelmConfig()
+	helmConfig, err := h.app.getHelmConfig(h.getStepName())
 	if err != nil {
 		log.Warn().Err(err).Msg(h.app.Msg(h.getStepName(), "Unable to get helm config"))
 		return "", err
@@ -92,24 +91,6 @@ func (h *Helm) Render(_ string) (string, error) {
 
 	log.Info().Msg(h.app.Msg(h.getStepName(), "Helm chart rendered"))
 	return strings.Join(outputs, "---\n"), nil
-}
-
-func (h *Helm) getHelmConfig() (HelmConfig, error) {
-	dataValuesYaml, err := h.app.ytt(h.getStepName(), "get helm config", h.app.yttDataFiles, "--data-values-inspect")
-	if err != nil {
-		return HelmConfig{}, err
-	}
-
-	var helmConfig struct {
-		Helm HelmConfig
-	}
-	err = yaml.Unmarshal([]byte(dataValuesYaml.Stdout), &helmConfig)
-	if err != nil {
-		log.Warn().Err(err).Msg(h.app.Msg(h.getStepName(), "Unable to unmarshal data values"))
-		return HelmConfig{}, err
-	}
-
-	return helmConfig.Helm, nil
 }
 
 func (h *Helm) getStepName() string {


### PR DESCRIPTION
I am using myks for my home automation. I have Argo disabled and roll out with kapp via myks plugin. However, kapp errors on non-existent namespaces. Therefore, I need a means to create the beforehand.