### PR TITLE
fix: switch generated data values to schema to lower priority

### DIFF
--- a/internal/myks/globe.go
+++ b/internal/myks/globe.go
@@ -367,7 +367,7 @@ func (g *Globe) dumpConfigAsYaml() (string, error) {
 	if err := enc.Encode(configData); err != nil {
 		return "", err
 	}
-	yttData := fmt.Sprintf("#@data/values\n---\n%s", yamlData.String())
+	yttData := fmt.Sprintf("#@data/values-schema\n---\n%s", yamlData.String())
 
 	configFileName := filepath.Join(g.RootDir, g.ServiceDirName, g.TempDirName, g.MyksDataFileName)
 	if err := os.MkdirAll(filepath.Dir(configFileName), 0o750); err != nil {


### PR DESCRIPTION
This fixes the issue when it is not possible to override values automatically set via `.myks/tmp/myks-data.ytt.yaml` with values set in e.g. `envs/env-data.ytt.yaml`, if `envs/env-data.ytt.yaml` is `data/values-schema`.
`data/values` files have higher precedence than `data/values-schema` files, so the values set in `data/values` files will override the values set in `data/values-schema` files.
