### PR TITLE
fix: adjust the initial .gitignore for the latest changes

### DIFF
--- a/internal/myks/assets/gitignore
+++ b/internal/myks/assets/gitignore
@@ -1,1 +1,4 @@
-**/.myks/tmp/
+.myks/tmp
+.myks/envs/**/helm
+.myks/envs/**/steps
+.myks/envs/**/argocd_defaults.ytt.yaml

--- a/internal/myks/assets/gitignore
+++ b/internal/myks/assets/gitignore
@@ -1,4 +1,1 @@
-.myks/tmp
-.myks/envs/**/helm
-.myks/envs/**/steps
-.myks/envs/**/argocd_defaults.ytt.yaml
+.myks


### PR DESCRIPTION
This PR updates the `.gitignore` file that is created by the `myks init` command to reflect the latest changes in the `.myks` directory.

With these changes, the following files are ignored:

- `.myks/tmp`: data schema and values files managed by `myks` and refreshed on every run
- `.myks/envs/**/helm`: helm values files generated by `myks` on every render of this app
- `.myks/envs/**/steps`: yaml files with intermediate results of the rendering steps
- `.myks/envs/**/argocd_defaults.ytt.yaml`: generated on every run default data values for the ArgoCD plugin

What is not ignored by default (these files are useful for debugging and tracking upstream changes in PRs):

- `.myks/vendir-cache`: vendir cache entries
  - this probably should be ignored by default, users can decide whether to carry the cache in git or not;
    I personally keep it in git to track upstream changes, but now, for every update, there are a lot of renames that clutter PR diffs
    Here is an example of such PR: https://github.com/Zebradil/myks-homelab/pull/130/files
- `.myks/envs/**/env-data.yaml`: generated data values files for environments, useful to see the final definition of an environment
- `.myks/envs/**/vendor`: directory with links to the vendir cache entries
- `.myks/envs/**/vendir-links.yaml`: map of vendor directories to cache entries
- `.myks/envs/**/vendir.yaml`: generated vendir configuration file for this application

It feels like we can completely ignore the `.myks` directory by default and provide hints to users to include some of the ignored files and directories to satisfy particular use cases.
