### PR TITLE
fix: skip ArgoCD Application plugin if not set

### DIFF
--- a/examples/integration-tests/envs/dev/_apps/argocd-tests/app-data.ytt.yaml
+++ b/examples/integration-tests/envs/dev/_apps/argocd-tests/app-data.ytt.yaml
@@ -1,0 +1,6 @@
+#@data/values
+---
+argocd:
+  app:
+    source:
+      plugin: null

--- a/examples/integration-tests/envs/dev/env-data.ytt.yaml
+++ b/examples/integration-tests/envs/dev/env-data.ytt.yaml
@@ -5,6 +5,8 @@ environment:
   #! applications:  # already defined one level above
   #!  - proto: httpbingo # already defined one level above
   applications:
+    - proto: ytt-render-test
+      name: argocd-tests
     - proto: helm-render-test
       name: helm-installation
     - proto: per-chart-override

--- a/examples/integration-tests/rendered/argocd/mykso-dev/app-argocd-tests.yaml
+++ b/examples/integration-tests/rendered/argocd/mykso-dev/app-argocd-tests.yaml
@@ -1,17 +1,17 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: mykso-prod-httpbingo
-  namespace: argocd
+  name: app-mykso-dev-argocd-tests
+  namespace: system-argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
-  project: mykso-prod
+  project: env-mykso-dev
   destination:
-    name: mykso-prod
-    namespace: httpbingo
+    name: mykso-dev
+    namespace: argocd-tests
   source:
-    path: examples/simple/rendered/envs/mykso-prod/httpbingo
+    path: examples/integration-tests/rendered/envs/mykso-dev/argocd-tests
     repoURL: git@github.com:mykso/myks.git
     targetRevision: main
   syncPolicy:

--- a/examples/integration-tests/rendered/envs/mykso-dev/argocd-tests/rendering-base.yaml
+++ b/examples/integration-tests/rendered/envs/mykso-dev/argocd-tests/rendering-base.yaml
@@ -1,0 +1,6 @@
+kind: rendering
+metadata:
+  name: base
+outputYaml:
+  fromPrototype: true
+  fromPrototypeAppData: true

--- a/examples/integration-tests/rendered/envs/mykso-dev/argocd-tests/rendering-proto.yaml
+++ b/examples/integration-tests/rendered/envs/mykso-dev/argocd-tests/rendering-proto.yaml
@@ -1,0 +1,6 @@
+kind: rendering
+metadata:
+  name: proto
+outputYaml:
+  fromPrototypeOverride: true
+  fromPrototypeOverrideFromAppData: true

--- a/examples/simple/rendered/argocd/mykso-dev/app-httpbingo.yaml
+++ b/examples/simple/rendered/argocd/mykso-dev/app-httpbingo.yaml
@@ -12,7 +12,6 @@ spec:
     namespace: httpbingo
   source:
     path: examples/simple/rendered/envs/mykso-dev/httpbingo
-    plugin: null
     repoURL: git@github.com:mykso/myks.git
     targetRevision: main
   syncPolicy:

--- a/internal/myks/templates/argocd/application.ytt.yaml
+++ b/internal/myks/templates/argocd/application.ytt.yaml
@@ -25,6 +25,7 @@ spec:
     namespace: #@ a.app.destination.namespace or a.app.name
   source:
     path: #@ a.app.source.path
+    #@ if/end a.app.source.plugin:
     plugin: #@ a.app.source.plugin
     repoURL: #@ a.app.source.repoURL
     targetRevision: #@ a.app.source.targetRevision


### PR DESCRIPTION
By default `argocd.app.source.plugin` is set to `null`.
This value is rendered literally in the ArgoCD Applicaion CR,
which causes the ArgoCD to fail to sync the application,
as ArgoCD expects an object here.

This PR changes the Application template to omit the field if it's empty.
