### PR TITLE
fix: make per-chart helm options nullable

### DIFF
--- a/internal/myks/assets/data-schema.ytt.yaml
+++ b/internal/myks/assets/data-schema.ytt.yaml
@@ -106,7 +106,9 @@ helm:
   #! See https://github.com/carvel-dev/ytt/issues/656 for more information.
   #@schema/validation ("chart names must be unique", lambda x: len(set([c["name"] for c in x])) == len(x))
   charts:
-    - buildDependencies: false
+    - #@schema/nullable
+      buildDependencies: false
+      #@schema/nullable
       includeCRDs: false
       #@schema/validation min_len=1
       name: ""


### PR DESCRIPTION
This PR fixes an issue when the default values of boolean `helm.*` options are owerwritten by default values of the corresponding `helm.charts.*` options.

For example, with all default values, `includeCRDs` option becomes disabled, whereas it is expected to be enabled by default.
