### PR TITLE
fix: ensure buildDependencies is nullable

### DIFF
--- a/internal/myks/assets/data-schema.ytt.yaml
+++ b/internal/myks/assets/data-schema.ytt.yaml
@@ -106,14 +106,14 @@ helm:
   #! See https://github.com/carvel-dev/ytt/issues/656 for more information.
   #@schema/validation ("chart names must be unique", lambda x: len(set([c["name"] for c in x])) == len(x))
   charts:
-    - #@schema/nullable
+    - releaseName: ""
+      #@schema/nullable
       buildDependencies: false
       #@schema/nullable
       includeCRDs: false
       #@schema/validation min_len=1
       name: ""
       namespace: ""
-      releaseName: ""
 #! Configuration of the step that renders ytt-packages.
 yttPkg:
   #! A ytt-package can be rendered as a whole, or can contain multiple sub-packages that should be rendered separately.


### PR DESCRIPTION
In YTT an annotation affects either its left node or its right node, in this
exact order. To make sure the annotation is applied to the bottom node, we have
to ensure there's no node to the left of it.

In this case, the `releaseName` key is moved to the top of the list, to achieve
that.
