### PR TITLE
fix: correctly assign apps to nested envs

### DIFF
--- a/internal/myks/globe.go
+++ b/internal/myks/globe.go
@@ -392,8 +392,8 @@ func (g *Globe) collectEnvironments(envSearchPathToAppMap EnvAppMap) EnvAppMap {
 
 	for searchPath, appNames := range envSearchPathToAppMap {
 		for _, envPath := range g.collectEnvironmentsInPath(searchPath) {
-			// If appNames is nil, it means all applications in the environment should be processed
-			if appNames == nil {
+			// If appNames is nil or empty, it means all applications in the environment should be processed
+			if len(appNames) == 0 {
 				envAppMap[envPath] = nil
 				continue
 			}

--- a/internal/myks/globe.go
+++ b/internal/myks/globe.go
@@ -406,6 +406,9 @@ func (g *Globe) collectEnvironments(envSearchPathToAppMap EnvAppMap) EnvAppMap {
 			}
 		}
 	}
+	for env, apps := range envAppMap {
+		envAppMap[env] = unique(apps)
+	}
 
 	log.Debug().Interface("envToAppMap", envAppMap).Msg(g.Msg("Collected environments"))
 	return envAppMap

--- a/internal/myks/globe_test.go
+++ b/internal/myks/globe_test.go
@@ -1,6 +1,7 @@
 package myks
 
 import (
+	"sort"
 	"testing"
 )
 
@@ -25,4 +26,118 @@ func Test_AddBaseDirToEnvPath(t *testing.T) {
 			t.Errorf("addBaseDirToEnvPath(%s) = %s; want %s", tt.in, out, tt.out)
 		}
 	}
+}
+
+func Test_collectEnvironments(t *testing.T) {
+	defer chdir(t, "../../testData/collect-environments")()
+
+	g := NewWithDefaults()
+	g.environments = make(map[string]*Environment)
+	tests := []struct {
+		name string
+		in   EnvAppMap
+		out  EnvAppMap
+	}{
+		{
+			"empty map",
+			EnvAppMap{},
+			EnvAppMap{
+				"envs/bar/prod":  []string{},
+				"envs/bar/stage": []string{},
+				"envs/foo/prod":  []string{},
+				"envs/foo/stage": []string{},
+			},
+		},
+		{
+			"one env",
+			EnvAppMap{
+				"envs/bar/prod": []string{"app1", "app2"},
+			},
+			EnvAppMap{
+				"envs/bar/prod": []string{"app1", "app2"},
+			},
+		},
+		{
+			"multiple envs",
+			EnvAppMap{
+				"envs/bar/prod":  []string{"app1", "app2"},
+				"envs/bar/stage": []string{"app1", "app3"},
+				"envs/foo/prod":  []string{"app1"},
+			},
+			EnvAppMap{
+				"envs/bar/prod":  []string{"app1", "app2"},
+				"envs/bar/stage": []string{"app1", "app3"},
+				"envs/foo/prod":  []string{"app1"},
+			},
+		},
+		{
+			"nested envs",
+			EnvAppMap{
+				"envs":           []string{"app1", "envsApp"},
+				"envs/bar":       []string{"app2", "barApp"},
+				"envs/bar/stage": []string{"app3", "stageApp"},
+			},
+			EnvAppMap{
+				"envs/bar/prod":  []string{"app1", "envsApp", "app2", "barApp"},
+				"envs/bar/stage": []string{"app1", "envsApp", "app2", "barApp", "app3", "stageApp"},
+				"envs/foo/prod":  []string{"app1", "envsApp"},
+				"envs/foo/stage": []string{"app1", "envsApp"},
+			},
+		},
+		{
+			"deduplication",
+			EnvAppMap{
+				"envs/bar": []string{"app1", "app1", "app2"},
+			},
+			EnvAppMap{
+				"envs/bar/prod":  []string{"app1", "app2"},
+				"envs/bar/stage": []string{"app1", "app2"},
+			},
+		},
+		{
+			"empty list prioritised",
+			EnvAppMap{
+				"envs/bar":      nil,
+				"envs/bar/prod": []string{"app1", "app2"},
+				"envs/foo":      []string{},
+				"envs/foo/prod": []string{"app3"},
+			},
+			EnvAppMap{
+				"envs/bar/prod":  []string{},
+				"envs/bar/stage": []string{},
+				"envs/foo/prod":  []string{},
+				"envs/foo/stage": []string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		out := g.collectEnvironments(tt.in)
+		if !compareEnvAppMap(out, tt.out) {
+			t.Errorf("%s:\n  got  %v\n  want %v", tt.name, out, tt.out)
+		}
+	}
+}
+
+func compareEnvAppMap(left, right EnvAppMap) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for leftEnv, leftApps := range left {
+		if rightApps, ok := right[leftEnv]; !ok {
+			return false
+		} else {
+			if len(leftApps) != len(rightApps) {
+				return false
+			}
+			sort.Strings(leftApps)
+			sort.Strings(rightApps)
+			for i, leftApp := range leftApps {
+				if leftApp != rightApps[i] {
+					return false
+				}
+			}
+		}
+	}
+	return true
 }

--- a/testData/collect-environments/envs/bar/prod/env-data.ytt.yaml
+++ b/testData/collect-environments/envs/bar/prod/env-data.ytt.yaml
@@ -1,0 +1,2 @@
+environment:
+  id: bar-prod

--- a/testData/collect-environments/envs/bar/stage/env-data.ytt.yaml
+++ b/testData/collect-environments/envs/bar/stage/env-data.ytt.yaml
@@ -1,0 +1,2 @@
+environment:
+  id: bar-stage

--- a/testData/collect-environments/envs/foo/prod/env-data.ytt.yaml
+++ b/testData/collect-environments/envs/foo/prod/env-data.ytt.yaml
@@ -1,0 +1,2 @@
+environment:
+  id: foo-prod

--- a/testData/collect-environments/envs/foo/stage/env-data.ytt.yaml
+++ b/testData/collect-environments/envs/foo/stage/env-data.ytt.yaml
@@ -1,0 +1,2 @@
+environment:
+  id: foo-stage


### PR DESCRIPTION
Before, if myks is tasked to process several intersecting environments, the
application list from the last collected environment was winning.

For example, with the following search paths:

```
envs/foo: app1, app2
envs/foo/bar: app3
```

The environment `envs/foo/bar` was processed with `app3` instead of `app1`,
`app2`, and `app3`.

Moreover, empty application lists were not handled correctly. If an application
list is empty, all applications in the environment should be processed.
