### PR TITLE
refactor: use `any` type instead of `interface{}`

### DIFF
--- a/internal/myks/cache.go
+++ b/internal/myks/cache.go
@@ -7,23 +7,23 @@ import (
 	"strings"
 )
 
-func genCacheName(config map[string]interface{}) (string, error) {
+func genCacheName(config map[string]any) (string, error) {
 	if val, ok := config["helmChart"]; ok {
-		return helmCacheNamer(val.(map[string]interface{}))
+		return helmCacheNamer(val.(map[string]any))
 	}
 
 	if val, ok := config["directory"]; ok {
-		return directoryCacheNamer(val.(map[string]interface{}))
+		return directoryCacheNamer(val.(map[string]any))
 	}
 
 	if val, ok := config["git"]; ok {
-		return gitCacheNamer(val.(map[string]interface{}))
+		return gitCacheNamer(val.(map[string]any))
 	}
 
 	return defaultCacheNamer(config)
 }
 
-func defaultCacheNamer(config map[string]interface{}) (string, error) {
+func defaultCacheNamer(config map[string]any) (string, error) {
 	yaml, err := mapToStableString(config)
 	if err != nil {
 		return "", err
@@ -31,7 +31,7 @@ func defaultCacheNamer(config map[string]interface{}) (string, error) {
 	return fmt.Sprintf("unknown-%s", hashString(yaml)), nil
 }
 
-func helmCacheNamer(config map[string]interface{}) (string, error) {
+func helmCacheNamer(config map[string]any) (string, error) {
 	yaml, err := mapToStableString(config)
 	if err != nil {
 		return "", err
@@ -47,7 +47,7 @@ func helmCacheNamer(config map[string]interface{}) (string, error) {
 	return fmt.Sprintf("%s-%s-%s-%s", "helm", chartName, version, hashString(yaml)), nil
 }
 
-func gitCacheNamer(config map[string]interface{}) (string, error) {
+func gitCacheNamer(config map[string]any) (string, error) {
 	yaml, err := mapToStableString(config)
 	if err != nil {
 		return "", err
@@ -67,7 +67,7 @@ func gitCacheNamer(config map[string]interface{}) (string, error) {
 	return fmt.Sprintf("%s-%s-%s-%s", "git", dir, refSlug(ref), hashString(yaml)), nil
 }
 
-func directoryCacheNamer(config map[string]interface{}) (string, error) {
+func directoryCacheNamer(config map[string]any) (string, error) {
 	yaml, err := mapToStableString(config)
 	if err != nil {
 		return "", err

--- a/internal/myks/cache_test.go
+++ b/internal/myks/cache_test.go
@@ -3,29 +3,29 @@ package myks
 import "testing"
 
 func TestCacheNameGen(t *testing.T) {
-	helmConfig := map[string]interface{}{
-		"helmChart": map[string]interface{}{
+	helmConfig := map[string]any{
+		"helmChart": map[string]any{
 			"name":    "test",
 			"version": "1.1.0",
 		},
 	}
-	directoryConfig := map[string]interface{}{
-		"directory": map[string]interface{}{
+	directoryConfig := map[string]any{
+		"directory": map[string]any{
 			"path": "test",
 		},
 	}
-	gitConfig := map[string]interface{}{
-		"git": map[string]interface{}{
+	gitConfig := map[string]any{
+		"git": map[string]any{
 			"url": "https://kubernetes.github.io/ingress-nginx",
 			"ref": "feature/test",
 		},
 	}
-	unknownConfig := map[string]interface{}{
+	unknownConfig := map[string]any{
 		"unknown": "test",
 	}
 	tests := []struct {
 		name    string
-		config  map[string]interface{}
+		config  map[string]any
 		want    string
 		wantErr bool
 	}{
@@ -49,20 +49,20 @@ func TestCacheNameGen(t *testing.T) {
 }
 
 func TestCacheNamer_Helm(t *testing.T) {
-	validVendirConfig := map[string]interface{}{
+	validVendirConfig := map[string]any{
 		"name":    "test",
 		"version": "1.1.0",
 	}
-	vendirConfigWithoutVersion := map[string]interface{}{
+	vendirConfigWithoutVersion := map[string]any{
 		"name": "test",
 	}
-	vendirConfigWithoutName := map[string]interface{}{
+	vendirConfigWithoutName := map[string]any{
 		"version": "1.1.0",
 	}
 
 	tests := []struct {
 		name         string
-		vendirConfig map[string]interface{}
+		vendirConfig map[string]any
 		want         string
 		wantErr      bool
 	}{
@@ -85,16 +85,16 @@ func TestCacheNamer_Helm(t *testing.T) {
 }
 
 func TestCacheNamer_Directory(t *testing.T) {
-	validVendirConfig := map[string]interface{}{
+	validVendirConfig := map[string]any{
 		"path": "test",
 	}
-	vendirConfigWithoutPath := map[string]interface{}{
+	vendirConfigWithoutPath := map[string]any{
 		"name": "test",
 	}
 
 	tests := []struct {
 		name         string
-		vendirConfig map[string]interface{}
+		vendirConfig map[string]any
 		want         string
 		wantErr      bool
 	}{
@@ -116,20 +116,20 @@ func TestCacheNamer_Directory(t *testing.T) {
 }
 
 func TestCacheNamer_Git(t *testing.T) {
-	validVendirConfig := map[string]interface{}{
+	validVendirConfig := map[string]any{
 		"url": "https://kubernetes.github.io/ingress-nginx",
 		"ref": "feature/test",
 	}
-	vendirConfigWithoutURL := map[string]interface{}{
+	vendirConfigWithoutURL := map[string]any{
 		"ref": "main",
 	}
-	vendirConfigWithoutRef := map[string]interface{}{
+	vendirConfigWithoutRef := map[string]any{
 		"url": "https://kubernetes.github.io/ingress-nginx",
 	}
 
 	tests := []struct {
 		name         string
-		vendirConfig map[string]interface{}
+		vendirConfig map[string]any
 		want         string
 		wantErr      bool
 	}{

--- a/internal/myks/environment.go
+++ b/internal/myks/environment.go
@@ -66,7 +66,7 @@ func (e *Environment) Init(applicationNames []string) error {
 }
 
 func (e *Environment) Sync(asyncLevel int, syncTool SyncTool, vendirSecrets string) error {
-	return process(asyncLevel, e.Applications, func(item interface{}) error {
+	return process(asyncLevel, e.Applications, func(item any) error {
 		app, ok := item.(*Application)
 		if !ok {
 			return fmt.Errorf("unable to cast item to *Application")
@@ -79,7 +79,7 @@ func (e *Environment) Render(asyncLevel int) error {
 	if err := e.renderArgoCD(); err != nil {
 		return err
 	}
-	err := process(asyncLevel, e.Applications, func(item interface{}) error {
+	err := process(asyncLevel, e.Applications, func(item any) error {
 		app, ok := item.(*Application)
 		if !ok {
 			return fmt.Errorf("unable to cast item to *Application")
@@ -109,7 +109,7 @@ func (e *Environment) Render(asyncLevel int) error {
 }
 
 func (e *Environment) ExecPlugin(asyncLevel int, p Plugin, args []string) error {
-	return process(asyncLevel, e.Applications, func(item interface{}) error {
+	return process(asyncLevel, e.Applications, func(item any) error {
 		app, ok := item.(*Application)
 		if !ok {
 			return fmt.Errorf("unable to cast item to *Application")

--- a/internal/myks/globe.go
+++ b/internal/myks/globe.go
@@ -198,7 +198,7 @@ func (g *Globe) Init(asyncLevel int, envSearchPathToAppMap EnvAppMap) error {
 	envAppMap := g.collectEnvironments(g.AddBaseDirToEnvAppMap(envSearchPathToAppMap))
 	log.Debug().Interface("envAppMap", envAppMap).Msg(g.Msg("Environments collected from search paths"))
 
-	return process(asyncLevel, maps.Keys(envAppMap), func(item interface{}) error {
+	return process(asyncLevel, maps.Keys(envAppMap), func(item any) error {
 		envPath, ok := item.(string)
 		if !ok {
 			return fmt.Errorf("unable to cast item to string")
@@ -222,7 +222,7 @@ func (g *Globe) Sync(asyncLevel int) error {
 		if err != nil {
 			return err
 		}
-		err = process(asyncLevel, g.environments, func(item interface{}) error {
+		err = process(asyncLevel, g.environments, func(item any) error {
 			env, ok := item.(*Environment)
 			if !ok {
 				return fmt.Errorf("unable to cast item to *Environment")
@@ -237,7 +237,7 @@ func (g *Globe) Sync(asyncLevel int) error {
 }
 
 func (g *Globe) Render(asyncLevel int) error {
-	return process(asyncLevel, g.environments, func(item interface{}) error {
+	return process(asyncLevel, g.environments, func(item any) error {
 		env, ok := item.(*Environment)
 		if !ok {
 			return fmt.Errorf("unable to cast item to *Environment")
@@ -256,7 +256,7 @@ func (g *Globe) SyncAndRender(asyncLevel int) error {
 
 // ExecPlugin executes a plugin in the context of the globe
 func (g *Globe) ExecPlugin(asyncLevel int, p Plugin, args []string) error {
-	return process(asyncLevel, g.environments, func(item interface{}) error {
+	return process(asyncLevel, g.environments, func(item any) error {
 		env, ok := item.(*Environment)
 		if !ok {
 			return fmt.Errorf("unable to cast item to *Environment")

--- a/internal/myks/render.go
+++ b/internal/myks/render.go
@@ -86,7 +86,7 @@ func (a *Application) runSliceFormatStore(previousStepFile string) error {
 			continue
 		}
 
-		var obj map[string]interface{}
+		var obj map[string]any
 		if err = yaml.Unmarshal([]byte(document), &obj); err != nil {
 			log.Warn().Err(err).Str("file", previousStepFile).Msg(a.Msg(sliceStepName, "Unable to unmarshal yaml"))
 			return err
@@ -133,7 +133,7 @@ func (a *Application) getDestinationDir() string {
 }
 
 // Generates a file name for each document using kind and name if available
-func genRenderedResourceFileName(resource map[string]interface{}, includeNamespace bool) (string, error) {
+func genRenderedResourceFileName(resource map[string]any, includeNamespace bool) (string, error) {
 	kind := "NO_KIND"
 	if g, ok := resource["kind"]; ok {
 		kind = g.(string)
@@ -141,7 +141,7 @@ func genRenderedResourceFileName(resource map[string]interface{}, includeNamespa
 	name := "NO_NAME"
 	namespace := ""
 	if n, ok := resource["metadata"]; ok {
-		metadata := n.(map[string]interface{})
+		metadata := n.(map[string]any)
 		if n, ok := metadata["name"].(string); ok {
 			name = n
 		}

--- a/internal/myks/render_test.go
+++ b/internal/myks/render_test.go
@@ -122,7 +122,7 @@ func TestApplication_Render(t *testing.T) {
 
 func Test_genRenderedResourceFileName(t *testing.T) {
 	type args struct {
-		resource         map[string]interface{}
+		resource         map[string]any
 		includeNamespace bool
 	}
 	tests := []struct {
@@ -131,10 +131,10 @@ func Test_genRenderedResourceFileName(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"happy path", args{map[string]interface{}{"kind": "Deployment", "metadata": map[string]interface{}{"name": "test", "namespace": "test-ns"}}, true}, "deployment-test_test-ns.yaml", false},
-		{"no namespace", args{map[string]interface{}{"kind": "Deployment", "metadata": map[string]interface{}{"name": "test", "namespace": "test-ns"}}, false}, "deployment-test.yaml", false},
-		{"no kind", args{map[string]interface{}{"metadata": map[string]interface{}{"name": "test", "namespace": "test-ns"}}, false}, "", true},
-		{"no name", args{map[string]interface{}{"metadata": map[string]interface{}{"kind": "Deployment", "namespace": "test-ns"}}, false}, "", true},
+		{"happy path", args{map[string]any{"kind": "Deployment", "metadata": map[string]any{"name": "test", "namespace": "test-ns"}}, true}, "deployment-test_test-ns.yaml", false},
+		{"no namespace", args{map[string]any{"kind": "Deployment", "metadata": map[string]any{"name": "test", "namespace": "test-ns"}}, false}, "deployment-test.yaml", false},
+		{"no kind", args{map[string]any{"metadata": map[string]any{"name": "test", "namespace": "test-ns"}}, false}, "", true},
+		{"no name", args{map[string]any{"metadata": map[string]any{"kind": "Deployment", "namespace": "test-ns"}}, false}, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/myks/smart_mode.go
+++ b/internal/myks/smart_mode.go
@@ -18,7 +18,7 @@ func (g *Globe) DetectChangedEnvsAndApps(baseRevision string) (EnvAppMap, error)
 	// envAppMap is built later by calling g.runSmartMode
 	_ = g.collectEnvironments(nil)
 
-	err := process(0, g.environments, func(item interface{}) error {
+	err := process(0, g.environments, func(item any) error {
 		env, ok := item.(*Environment)
 		if !ok {
 			return fmt.Errorf("unable to cast item to *Environment")

--- a/internal/myks/sync_helm.go
+++ b/internal/myks/sync_helm.go
@@ -75,8 +75,8 @@ func (hr *HelmSyncer) helmBuild(a *Application, chartDir string) error {
 		"--repository-cache", filepath.Join(helmCache, "repository"),
 		"--repository-config", filepath.Join(helmCache, "repositories.yaml"),
 	}
-	for _, dependency := range dependencies.([]interface{}) {
-		depMap := dependency.(map[string]interface{})
+	for _, dependency := range dependencies.([]any) {
+		depMap := dependency.(map[string]any)
 		repo := depMap["repository"].(string)
 		if strings.HasPrefix(repo, "http") {
 			args := []string{"repo", "add", createURLSlug(repo), repo, "--force-update"}

--- a/internal/myks/sync_vendir.go
+++ b/internal/myks/sync_vendir.go
@@ -174,13 +174,13 @@ func (v *VendirSyncer) extractCacheItems(a *Application) error {
 
 	vendorDirToCacheMap := map[string]string{}
 
-	for _, dir := range vendirConfig["directories"].([]interface{}) {
-		dirMap := dir.(map[string]interface{})
-		contents := dirMap["contents"].([]interface{})
+	for _, dir := range vendirConfig["directories"].([]any) {
+		dirMap := dir.(map[string]any)
+		contents := dirMap["contents"].([]any)
 
 		for _, content := range contents {
-			vendorDirPath := filepath.Join(dirMap["path"].(string), content.(map[string]interface{})["path"].(string))
-			contentMap := content.(map[string]interface{})
+			vendorDirPath := filepath.Join(dirMap["path"].(string), content.(map[string]any)["path"].(string))
+			contentMap := content.(map[string]any)
 			cacheName, err := genCacheName(contentMap)
 			if err != nil {
 				return err
@@ -200,7 +200,7 @@ func (a *Application) getCacheVendirConfigPath(cacheName string) string {
 	return path.Join(a.expandVendirCache(cacheName), a.e.g.VendirConfigFileName)
 }
 
-func (v *VendirSyncer) saveCacheVendirConfig(a *Application, cacheName string, vendirConfig map[string]interface{}) error {
+func (v *VendirSyncer) saveCacheVendirConfig(a *Application, cacheName string, vendirConfig map[string]any) error {
 	data, err := yaml.Marshal(vendirConfig)
 	if err != nil {
 		log.Warn().Err(err).Msg(a.Msg(v.getStepName(), "Unable to marshal vendir config"))
@@ -216,23 +216,23 @@ func (v *VendirSyncer) saveCacheVendirConfig(a *Application, cacheName string, v
 	return nil
 }
 
-func buildCacheVendirConfig(cacheDir string, vendirConfig, vendirDirConfig, vendirContentConfig map[string]interface{}) map[string]interface{} {
+func buildCacheVendirConfig(cacheDir string, vendirConfig, vendirDirConfig, vendirContentConfig map[string]any) map[string]any {
 	knownKeys := []string{"apiVersion", "kind", "minimumRequiredVersion"}
-	newVendirConfig := map[string]interface{}{}
+	newVendirConfig := map[string]any{}
 	for _, key := range knownKeys {
 		if val, ok := vendirConfig[key]; ok {
 			newVendirConfig[key] = val
 		}
 	}
 
-	newDirConfig := map[string]interface{}{}
+	newDirConfig := map[string]any{}
 	newDirConfig["path"] = filepath.Join(cacheDir, VendirCacheDataDirName)
 	newDirConfig["permissions"] = vendirDirConfig["permissions"]
 
 	vendirContentConfig["path"] = "."
 
-	newDirConfig["contents"] = []interface{}{vendirContentConfig}
-	newVendirConfig["directories"] = []interface{}{newDirConfig}
+	newDirConfig["contents"] = []any{vendirContentConfig}
+	newVendirConfig["directories"] = []any{newDirConfig}
 	return newVendirConfig
 }
 

--- a/internal/myks/util.go
+++ b/internal/myks/util.go
@@ -53,8 +53,8 @@ func printFileNicely(name, content, syntax string) {
 	}
 }
 
-func process(asyncLevel int, collection interface{}, fn func(interface{}) error) error {
-	var items []interface{}
+func process(asyncLevel int, collection any, fn func(any) error) error {
+	var items []any
 
 	value := reflect.ValueOf(collection)
 	switch value.Kind() {
@@ -154,13 +154,13 @@ func copyFileSystemToPath(source fs.FS, sourcePath string, destinationPath strin
 	return err
 }
 
-func unmarshalYamlToMap(filePath string) (map[string]interface{}, error) {
+func unmarshalYamlToMap(filePath string) (map[string]any, error) {
 	ok, err := isExist(filePath)
 	if err != nil {
 		return nil, err
 	}
 	if !ok {
-		return make(map[string]interface{}), nil
+		return make(map[string]any), nil
 	}
 
 	file, err := os.ReadFile(filePath)
@@ -168,7 +168,7 @@ func unmarshalYamlToMap(filePath string) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	var config map[string]interface{}
+	var config map[string]any
 	err = yaml.Unmarshal(file, &config)
 	if err != nil {
 		return nil, err
@@ -176,7 +176,7 @@ func unmarshalYamlToMap(filePath string) (map[string]interface{}, error) {
 	return config, nil
 }
 
-func mapToStableString(yaml map[string]interface{}) (string, error) {
+func mapToStableString(yaml map[string]any) (string, error) {
 	if yaml == nil {
 		return "", nil
 	}
@@ -189,7 +189,7 @@ func mapToStableString(yaml map[string]interface{}) (string, error) {
 }
 
 func sortYaml(content []byte) ([]byte, error) {
-	var obj map[string]interface{}
+	var obj map[string]any
 	if err := yaml.Unmarshal(content, &obj); err != nil {
 		return nil, err
 	}

--- a/internal/myks/util_test.go
+++ b/internal/myks/util_test.go
@@ -37,19 +37,19 @@ func Test_hash(t *testing.T) {
 func Test_mapToStableString(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    map[string]interface{}
+		args    map[string]any
 		want    string
 		wantErr bool
 	}{
 		{
 			"happy path",
-			map[string]interface{}{"key1": "A", "key2": "B"},
+			map[string]any{"key1": "A", "key2": "B"},
 			"map[key1:A key2:B]",
 			false,
 		},
 		{
 			"fix sorting",
-			map[string]interface{}{"key2": "B", "key1": "A"},
+			map[string]any{"key2": "B", "key1": "A"},
 			"map[key1:A key2:B]",
 			false,
 		},
@@ -81,11 +81,11 @@ func Test_unmarshalYaml(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    map[string]interface{}
+		want    map[string]any
 		wantErr bool
 	}{
-		{"happy path", args{"../../testData/util/yaml/simple.yaml"}, map[string]interface{}{"key1": "A", "key2": "B", "arr": []interface{}{"arr1", "arr2"}}, false},
-		{"file not exist", args{"non-existing.yaml"}, map[string]interface{}{}, false},
+		{"happy path", args{"../../testData/util/yaml/simple.yaml"}, map[string]any{"key1": "A", "key2": "B", "arr": []any{"arr1", "arr2"}}, false},
+		{"file not exist", args{"non-existing.yaml"}, map[string]any{}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -288,9 +288,9 @@ func TestProcess(t *testing.T) {
 	testCases := []struct {
 		name            string
 		asyncLevel      int
-		collection      interface{}
+		collection      any
 		expectedFnCalls int
-		fn              func(interface{}) error
+		fn              func(any) error
 		expectedErr     error
 	}{
 		{
@@ -298,7 +298,7 @@ func TestProcess(t *testing.T) {
 			asyncLevel:      2,
 			collection:      []int{1, 2, 3, 4, 5},
 			expectedFnCalls: 5,
-			fn: func(item interface{}) error {
+			fn: func(item any) error {
 				return nil
 			},
 			expectedErr: nil,
@@ -308,7 +308,7 @@ func TestProcess(t *testing.T) {
 			asyncLevel:      2,
 			collection:      map[string]int{"one": 1, "two": 2, "three": 3},
 			expectedFnCalls: 3,
-			fn: func(item interface{}) error {
+			fn: func(item any) error {
 				return nil
 			},
 			expectedErr: nil,
@@ -318,7 +318,7 @@ func TestProcess(t *testing.T) {
 			asyncLevel:      0,
 			collection:      []int{1, 2, 3, 4, 5},
 			expectedFnCalls: 5,
-			fn: func(item interface{}) error {
+			fn: func(item any) error {
 				return nil
 			},
 			expectedErr: nil,
@@ -328,7 +328,7 @@ func TestProcess(t *testing.T) {
 			asyncLevel:      0,
 			collection:      map[string]int{"one": 1, "two": 2, "three": 3},
 			expectedFnCalls: 3,
-			fn: func(item interface{}) error {
+			fn: func(item any) error {
 				return nil
 			},
 			expectedErr: nil,
@@ -338,7 +338,7 @@ func TestProcess(t *testing.T) {
 			asyncLevel:      222,
 			collection:      []int{1, 2, 3, 4, 5},
 			expectedFnCalls: 5,
-			fn: func(item interface{}) error {
+			fn: func(item any) error {
 				return nil
 			},
 			expectedErr: nil,
@@ -347,7 +347,7 @@ func TestProcess(t *testing.T) {
 			name:       "Error in processing slice",
 			asyncLevel: 2,
 			collection: []int{1, 2, 3, 4, 5},
-			fn: func(item interface{}) error {
+			fn: func(item any) error {
 				if item.(int) == 3 {
 					return errors.New("error processing item")
 				}
@@ -359,7 +359,7 @@ func TestProcess(t *testing.T) {
 			name:       "Error in processing map",
 			asyncLevel: 2,
 			collection: map[string]int{"one": 1, "two": 2, "three": 3},
-			fn: func(item interface{}) error {
+			fn: func(item any) error {
 				if item.(int) == 2 {
 					return errors.New("error processing item")
 				}
@@ -371,7 +371,7 @@ func TestProcess(t *testing.T) {
 			name:       "Invalid collection type",
 			asyncLevel: 2,
 			collection: 42,
-			fn: func(item interface{}) error {
+			fn: func(item any) error {
 				return nil
 			},
 			expectedErr: fmt.Errorf("collection must be a slice, array or map, got %s", reflect.Int),
@@ -383,7 +383,7 @@ func TestProcess(t *testing.T) {
 			var counter int
 			var mu sync.Mutex
 
-			fnWrapper := func(item interface{}) error {
+			fnWrapper := func(item any) error {
 				mu.Lock()
 				counter++
 				mu.Unlock()
@@ -402,13 +402,13 @@ func TestProcess(t *testing.T) {
 	}
 }
 
-func assertEqual(t *testing.T, got, want interface{}) {
+func assertEqual(t *testing.T, got, want any) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("expected:\n%v\nGot:\n%v\nDifference:\n%v", want, got, diff(want, got))
 	}
 }
 
-func diff(expected, actual interface{}) string {
+func diff(expected, actual any) string {
 	jsonExpected, err := json.MarshalIndent(expected, "", "  ")
 	if err != nil {
 		return err.Error()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced internal consistency by modernizing type definitions across core functionalities. These changes improve maintainability and align with modern language conventions without altering user-facing behavior.

- **Tests**
  - Updated test suites to match the refined type conventions, ensuring robust validation and smoother future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->