### PR TITLE
revert: git-auto-commit-action to v5.2.0

### DIFF
--- a/.github/workflows/flow-pr.yml
+++ b/.github/workflows/flow-pr.yml
@@ -35,7 +35,7 @@ jobs:
           git_commit_gpgsign: true
       - name: Commit changes
         id: commit
-        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
         with:
           commit_message: 'chore: nix-update'
           commit_user_name: Mykso Bot


### PR DESCRIPTION
Revert "chore(deps): update stefanzweifel/git-auto-commit-action action to v6 (#531)"

This reverts commit daa2e5d1deb4230fdd7a5b307fcea7ce275ba736.

See https://github.com/stefanzweifel/git-auto-commit-action/issues/383
