### PR TITLE
feat: support global helm values

### DIFF
--- a/examples/integration-tests/envs/dev/_apps/multiple-sources/helm/_global.yaml
+++ b/examples/integration-tests/envs/dev/_apps/multiple-sources/helm/_global.yaml
@@ -1,0 +1,4 @@
+outputYaml:
+  fromAppGlobal: true
+  appSpecificChart: appGlobal
+  appGlobal: appGlobal

--- a/examples/integration-tests/envs/dev/_apps/multiple-sources/helm/render-test-1.yaml
+++ b/examples/integration-tests/envs/dev/_apps/multiple-sources/helm/render-test-1.yaml
@@ -1,0 +1,3 @@
+outputYaml:
+  fromAppSpecificChart: true
+  appSpecificChart: appSpecificChart

--- a/examples/integration-tests/prototypes/multiple-sources/helm/_global.yaml
+++ b/examples/integration-tests/prototypes/multiple-sources/helm/_global.yaml
@@ -1,0 +1,4 @@
+outputYaml:
+  fromPrototypeGlobal: true
+  appSpecificChart: prototypeGlobal
+  appGlobal: prototypeGlobal

--- a/examples/integration-tests/rendered/envs/mykso-dev/multiple-sources/rendering-helm-render-test-1.yaml
+++ b/examples/integration-tests/rendered/envs/mykso-dev/multiple-sources/rendering-helm-render-test-1.yaml
@@ -5,5 +5,6 @@ outputYaml:
   appGlobal: appGlobal
   appSpecificChart: appSpecificChart
   fromAppGlobal: true
+  fromAppSpecificChart: true
   fromChartDefaultValues: true
   fromPrototypeGlobal: true

--- a/examples/integration-tests/rendered/envs/mykso-dev/multiple-sources/rendering-helm-render-test-1.yaml
+++ b/examples/integration-tests/rendered/envs/mykso-dev/multiple-sources/rendering-helm-render-test-1.yaml
@@ -2,4 +2,8 @@ kind: rendering
 metadata:
   name: helm-render-test-1
 outputYaml:
+  appGlobal: appGlobal
+  appSpecificChart: appSpecificChart
+  fromAppGlobal: true
   fromChartDefaultValues: true
+  fromPrototypeGlobal: true

--- a/examples/integration-tests/rendered/envs/mykso-dev/multiple-sources/rendering-helm-render-test-2.yaml
+++ b/examples/integration-tests/rendered/envs/mykso-dev/multiple-sources/rendering-helm-render-test-2.yaml
@@ -2,4 +2,8 @@ kind: rendering
 metadata:
   name: helm-render-test-2
 outputYaml:
+  appGlobal: appGlobal
+  appSpecificChart: appGlobal
+  fromAppGlobal: true
   fromChartDefaultValues: true
+  fromPrototypeGlobal: true


### PR DESCRIPTION
This adds support for global helm values. These values are considered during rendering of each and every chart in an application.

How to use: place a `_global.yaml` file in the `helm` directory on any level of the inheritance tree – in the same directory you'd place a helm-specific values file.
All global helm values files are collected and included in rending of the final helm values file for every chart of an application.
Global values files have lower priority than chart specific ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new YAML configuration files for integration and prototype environments, providing additional global and chart-specific settings for Helm charts.

* **Bug Fixes**
  * Enhanced rendered output files with new flags and values to reflect more detailed rendering states.

* **Refactor**
  * Improved internal logic for collecting values files, resulting in cleaner and more maintainable code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->