### PR TITLE
fix(smart-mode): fix env path matching

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1o
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/chroma/v2 v2.18.0 h1:6h53Q4hW83SuF+jcsp7CVhLsMozzvQvO8HBbKQW+gn4=
-github.com/alecthomas/chroma/v2 v2.18.0/go.mod h1:RVX6AvYm4VfYe/zsk7mjHueLDZor3aWCNE14TFlepBk=
 github.com/alecthomas/chroma/v2 v2.19.0 h1:Im+SLRgT8maArxv81mULDWN8oKxkzboH07CHesxElq4=
 github.com/alecthomas/chroma/v2 v2.19.0/go.mod h1:RVX6AvYm4VfYe/zsk7mjHueLDZor3aWCNE14TFlepBk=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/internal/myks/globe.go
+++ b/internal/myks/globe.go
@@ -500,7 +500,10 @@ func (g *Globe) collectEnvironmentsInPath(searchPath string) []string {
 // or a parent directory of an existing environment path
 func (g *Globe) isEnvPath(path string) bool {
 	countParts := func(path string) int {
-		return len(strings.Split(path, string(filepath.Separator)))
+		if path == "" {
+			return 0
+		}
+		return strings.Count(path, string(filepath.Separator)) + 1
 	}
 
 	path = filepath.Clean(path)

--- a/internal/myks/globe.go
+++ b/internal/myks/globe.go
@@ -495,9 +495,20 @@ func (g *Globe) collectEnvironmentsInPath(searchPath string) []string {
 	return result
 }
 
+// isEnvPath checks if the path is a valid environment path
+// A valid path is either an exact match of an existing environment path
+// or a parent directory of an existing environment path
 func (g *Globe) isEnvPath(path string) bool {
+	countParts := func(path string) int {
+		return len(strings.Split(path, string(filepath.Separator)))
+	}
+
+	path = filepath.Clean(path)
 	for envPath := range g.environments {
-		if strings.HasPrefix(envPath, path) {
+		envPath = filepath.Clean(envPath)
+		// the second part of the condition ensures we don't do a partial match in the middle of a directory name
+		// e.g. envs/some should not match envs/something
+		if strings.HasPrefix(envPath, path) && (len(envPath) == len(path) || countParts(envPath) > countParts(path)) {
 			return true
 		}
 	}

--- a/internal/myks/globe_test.go
+++ b/internal/myks/globe_test.go
@@ -119,6 +119,82 @@ func Test_collectEnvironments(t *testing.T) {
 	}
 }
 
+func Test_isEnvPath(t *testing.T) {
+	g := NewWithDefaults()
+
+	// Set up test environments
+	g.environments = map[string]*Environment{
+		"envs/dev":         {},
+		"envs/staging":     {},
+		"envs/prod":        {},
+		"envs/team-a/dev":  {},
+		"envs/team-b/prod": {},
+		"envs/something":   {},
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "exact match",
+			path:     "envs/dev",
+			expected: true,
+		},
+		{
+			name:     "prefix match",
+			path:     "envs",
+			expected: true,
+		},
+		{
+			name:     "prefix match with separator",
+			path:     "envs/",
+			expected: true,
+		},
+		{
+			name:     "nested prefix match",
+			path:     "envs/team-a",
+			expected: true,
+		},
+		{
+			name:     "no match",
+			path:     "other/path",
+			expected: false,
+		},
+		{
+			name:     "similar prefix no match",
+			path:     "envs-other",
+			expected: false,
+		},
+
+		{
+			name:     "partial match but not prefix",
+			path:     "dev",
+			expected: false,
+		},
+		{
+			name:     "case sensitive no match",
+			path:     "ENVS/DEV",
+			expected: false,
+		},
+		{
+			name:     "partial prefix no match",
+			path:     "envs/some",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := g.isEnvPath(tt.path)
+			if result != tt.expected {
+				t.Errorf("isEnvPath(%q) = %v; want %v", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
 func compareEnvAppMap(left, right EnvAppMap) bool {
 	if len(left) != len(right) {
 		return false

--- a/internal/myks/globe_test.go
+++ b/internal/myks/globe_test.go
@@ -179,7 +179,7 @@ func Test_isEnvPath(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "partial prefix no match",
+			name:     "partial prefix no match (prevents envs/some matching envs/something)",
 			path:     "envs/some",
 			expected: false,
 		},

--- a/internal/myks/smart_mode.go
+++ b/internal/myks/smart_mode.go
@@ -133,7 +133,7 @@ func (g *Globe) runSmartMode(changedFiles ChangedFiles) EnvAppMap {
 	changedEnvs := []string{}
 	changedPrototypes := []string{}
 
-	for path := range maps.Keys(changedFiles) {
+	for path := range changedFiles {
 		// Check if the global configuration has changed
 		if extractMatches(exprMap["global"], path) != nil {
 			// If global configuration has changed, we need to render all environments


### PR DESCRIPTION
This fixes the issue where the smart mode would detect changes in a non-existent environment.
For example, when an environment is renamed from `envs/dev` to `envs/development`,
the smart mode would detect changes in `envs/dev`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved environment path recognition for more accurate path validation.

* **Tests**
  * Added comprehensive tests to verify environment path detection.

* **Refactor**
  * Streamlined internal processing for improved code clarity (no impact on user-facing functionality).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->