### PR TITLE
feat: add buffer option for plugin output handling

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -87,7 +87,8 @@ func newPluginCmd(plugin myks.Plugin) *cobra.Command {
 				return err
 			}
 
-			if err := g.ExecPlugin(asyncLevel, plugin, pluginArgs); err != nil {
+			bufferOutput := viper.GetBool("buffer-plugin-output")
+			if err := g.ExecPlugin(asyncLevel, plugin, pluginArgs, bufferOutput); err != nil {
 				log.Fatal().Err(err).Msg("Plugin did not run successfully")
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,6 +100,9 @@ LEARN MORE
 	smartModeOnlyPrintHelp := "only print the list of environments and applications that would be rendered in Smart Mode"
 	rootCmd.PersistentFlags().Bool("smart-mode.only-print", false, smartModeOnlyPrintHelp)
 
+	bufferPluginOutputHelp := "buffer plugin output instead of streaming (useful for parallel execution)"
+	rootCmd.PersistentFlags().Bool("buffer-plugin-output", false, bufferPluginOutputHelp)
+
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		log.Fatal().Err(err).Msg("Unable to bind flags")
 	}

--- a/internal/myks/environment.go
+++ b/internal/myks/environment.go
@@ -114,9 +114,9 @@ func (e *Environment) Render(asyncLevel int) error {
 	return e.Cleanup()
 }
 
-func (e *Environment) ExecPlugin(asyncLevel int, p Plugin, args []string) error {
+func (e *Environment) ExecPlugin(asyncLevel int, p Plugin, args []string, bufferOutput bool) error {
 	return process(asyncLevel, slices.Values(e.Applications), func(app *Application) error {
-		return p.Exec(app, args)
+		return p.Exec(app, args, bufferOutput)
 	})
 }
 

--- a/internal/myks/globe.go
+++ b/internal/myks/globe.go
@@ -250,9 +250,9 @@ func (g *Globe) SyncAndRender(asyncLevel int) error {
 }
 
 // ExecPlugin executes a plugin in the context of the globe
-func (g *Globe) ExecPlugin(asyncLevel int, p Plugin, args []string) error {
+func (g *Globe) ExecPlugin(asyncLevel int, p Plugin, args []string, bufferOutput bool) error {
 	return process(asyncLevel, maps.Values(g.environments), func(env *Environment) error {
-		return env.ExecPlugin(asyncLevel, p, args)
+		return env.ExecPlugin(asyncLevel, p, args, bufferOutput)
 	})
 }
 


### PR DESCRIPTION
Introduced a new flag to buffer plugin output instead of streaming, allowing for better control during parallel execution. Updated relevant functions and interfaces to support this feature.
