### PR TITLE
fix(kbld): invalidate lock file when Docker build context changes

### DIFF
--- a/.github/workflows/job-lint.yml
+++ b/.github/workflows/job-lint.yml
@@ -36,5 +36,8 @@ jobs:
             | tee /dev/stderr \
             | test $(wc -l) -eq 0
 
+      - name: Install mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        run: golangci-lint run

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[tools]
+golangci-lint = "2.10.1"

--- a/internal/myks/hashutil.go
+++ b/internal/myks/hashutil.go
@@ -79,6 +79,19 @@ func hashDirectory(dirPath string) (string, error) {
 		}
 
 		switch {
+		case d.IsDir():
+			// Skip the root itself; all other directories are hashed by path so
+			// that adding/removing empty directories invalidates the hash.
+			if relPath == "." {
+				return nil
+			}
+			// Hash: relPath NUL "dir" NUL
+			for _, part := range [][]byte{[]byte(relPath), nul, []byte("dir"), nul} {
+				if _, err := h.Write(part); err != nil {
+					return hasherErr(err)
+				}
+			}
+
 		case d.Type().IsRegular():
 			// Hash: relPath NUL file-content NUL
 			if _, err := h.Write([]byte(relPath)); err != nil {

--- a/internal/myks/hashutil.go
+++ b/internal/myks/hashutil.go
@@ -53,9 +53,6 @@ var nul = []byte{0}
 // to avoid circular-link issues). Other non-regular entries are skipped.
 func hashDirectory(dirPath string) (string, error) {
 	h := fnv.New64a()
-	hasherErr := func(err error) error {
-		return fmt.Errorf("hashing directory %s: %w", dirPath, err)
-	}
 
 	root, err := os.OpenRoot(dirPath)
 	if err != nil {
@@ -71,9 +68,8 @@ func hashDirectory(dirPath string) (string, error) {
 		if err != nil {
 			return err
 		}
-		path = filepath.Clean(path)
 
-		relPath, err := filepath.Rel(dirPath, path)
+		relPath, err := filepath.Rel(dirPath, filepath.Clean(path))
 		if err != nil {
 			return fmt.Errorf("getting relative path for %s: %w", path, err)
 		}
@@ -86,71 +82,78 @@ func hashDirectory(dirPath string) (string, error) {
 
 		switch {
 		case d.IsDir():
-			// Skip the root itself; all other directories are hashed by path so
-			// that adding/removing empty directories invalidates the hash.
-			if relPath == "." {
-				return nil
-			}
-			// Hash: relPath NUL "dir" NUL mode NUL
-			for _, part := range [][]byte{[]byte(relPath), nul, []byte("dir"), nul, mode, nul} {
-				if _, err := h.Write(part); err != nil {
-					return hasherErr(err)
-				}
-			}
-
+			return hashDirEntry(h, relPath, mode)
 		case d.Type().IsRegular():
-			// Hash: relPath NUL mode NUL file-content NUL
-			// Mode is included so that permission-only changes (e.g. chmod +x)
-			// invalidate the hash — important for Docker build contexts where
-			// the executable bit affects the resulting image.
-			if _, err := h.Write([]byte(relPath)); err != nil {
-				return hasherErr(err)
-			}
-			if _, err := h.Write(nul); err != nil {
-				return hasherErr(err)
-			}
-			if _, err := h.Write(mode); err != nil {
-				return hasherErr(err)
-			}
-			if _, err := h.Write(nul); err != nil {
-				return hasherErr(err)
-			}
-			file, err := root.Open(relPath)
-			if err != nil {
-				return fmt.Errorf("opening file %s: %w", relPath, err)
-			}
-			defer func() {
-				if closeErr := file.Close(); closeErr != nil {
-					log.Error().Err(closeErr).Msg("Failed to close file")
-				}
-			}()
-			if _, err := io.Copy(h, file); err != nil {
-				return hasherErr(err)
-			}
-			if _, err := h.Write(nul); err != nil {
-				return hasherErr(err)
-			}
-
+			return hashFileEntry(h, root, relPath, mode)
 		case d.Type()&fs.ModeSymlink != 0:
-			// Hash: relPath NUL "symlink:" linkTarget NUL mode NUL
-			// We hash the link target string rather than following it to avoid
-			// infinite loops on circular symlinks.
-			linkTarget, err := root.Readlink(relPath)
-			if err != nil {
-				return fmt.Errorf("reading link %s: %w", relPath, err)
-			}
-			parts := [][]byte{[]byte(relPath), nul, []byte("symlink:" + linkTarget), nul, mode, nul}
-			for _, part := range parts {
-				if _, err := h.Write(part); err != nil {
-					return hasherErr(err)
-				}
-			}
+			return hashSymlinkEntry(h, root, relPath, mode)
 		}
-
 		return nil
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to hash directory: %w", err)
 	}
 	return fmt.Sprintf("%x", h.Sum64()), nil
+}
+
+// hashDirEntry hashes a directory entry (path + mode) into h.
+// The root directory itself (relPath == ".") is skipped so that only its
+// contents, not its existence, affect the hash.
+func hashDirEntry(h io.Writer, relPath string, mode []byte) error {
+	if relPath == "." {
+		return nil
+	}
+	// Hash: relPath NUL "dir" NUL mode NUL
+	for _, part := range [][]byte{[]byte(relPath), nul, []byte("dir"), nul, mode, nul} {
+		if _, err := h.Write(part); err != nil {
+			return fmt.Errorf("writing to hasher: %w", err)
+		}
+	}
+	return nil
+}
+
+// hashFileEntry hashes a regular file (path + mode + content) into h.
+// Mode is included so that permission-only changes (e.g. chmod +x) invalidate
+// the hash — important for Docker build contexts where the executable bit
+// affects the resulting image.
+func hashFileEntry(h io.Writer, root *os.Root, relPath string, mode []byte) error {
+	for _, part := range [][]byte{[]byte(relPath), nul, mode, nul} {
+		if _, err := h.Write(part); err != nil {
+			return fmt.Errorf("writing to hasher: %w", err)
+		}
+	}
+
+	file, err := root.Open(relPath)
+	if err != nil {
+		return fmt.Errorf("opening file %s: %w", relPath, err)
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			log.Error().Err(closeErr).Msg("Failed to close file")
+		}
+	}()
+
+	if _, err := io.Copy(h, file); err != nil {
+		return fmt.Errorf("writing to hasher: %w", err)
+	}
+	if _, err := h.Write(nul); err != nil {
+		return fmt.Errorf("writing to hasher: %w", err)
+	}
+	return nil
+}
+
+// hashSymlinkEntry hashes a symlink (path + target + mode) into h.
+// The link target string is hashed rather than following it to avoid infinite
+// loops on circular symlinks.
+func hashSymlinkEntry(h io.Writer, root *os.Root, relPath string, mode []byte) error {
+	linkTarget, err := root.Readlink(relPath)
+	if err != nil {
+		return fmt.Errorf("reading link %s: %w", relPath, err)
+	}
+	for _, part := range [][]byte{[]byte(relPath), nul, []byte("symlink:" + linkTarget), nul, mode, nul} {
+		if _, err := h.Write(part); err != nil {
+			return fmt.Errorf("writing to hasher: %w", err)
+		}
+	}
+	return nil
 }

--- a/internal/myks/hashutil.go
+++ b/internal/myks/hashutil.go
@@ -53,28 +53,32 @@ var nul = []byte{0}
 // to avoid circular-link issues). Other non-regular entries are skipped.
 func hashDirectory(dirPath string) (string, error) {
 	h := fnv.New64a()
+	hasherErr := func(err error) error {
+		return fmt.Errorf("writing to hasher: %w", err)
+	}
 	err := filepath.WalkDir(dirPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
+		path = filepath.Clean(path)
 
 		relPath, err := filepath.Rel(dirPath, path)
 		if err != nil {
-			return err
+			return fmt.Errorf("getting relative path for %s: %w", path, err)
 		}
 
 		switch {
 		case d.Type().IsRegular():
 			// Hash: relPath NUL file-content NUL
 			if _, err := h.Write([]byte(relPath)); err != nil {
-				return err
+				return hasherErr(err)
 			}
 			if _, err := h.Write(nul); err != nil {
-				return err
+				return hasherErr(err)
 			}
-			file, err := os.Open(filepath.Clean(path))
+			file, err := os.Open(path)
 			if err != nil {
-				return err
+				return fmt.Errorf("opening file %s: %w", path, err)
 			}
 			defer func() {
 				if closeErr := file.Close(); closeErr != nil {
@@ -82,10 +86,10 @@ func hashDirectory(dirPath string) (string, error) {
 				}
 			}()
 			if _, err := io.Copy(h, file); err != nil {
-				return err
+				return hasherErr(err)
 			}
 			if _, err := h.Write(nul); err != nil {
-				return err
+				return hasherErr(err)
 			}
 
 		case d.Type()&fs.ModeSymlink != 0:
@@ -94,19 +98,13 @@ func hashDirectory(dirPath string) (string, error) {
 			// infinite loops on circular symlinks.
 			linkTarget, err := os.Readlink(path)
 			if err != nil {
-				return err
+				return fmt.Errorf("reading link %s: %w", path, err)
 			}
-			if _, err := h.Write([]byte(relPath)); err != nil {
-				return err
-			}
-			if _, err := h.Write(nul); err != nil {
-				return err
-			}
-			if _, err := h.Write([]byte("symlink:" + linkTarget)); err != nil {
-				return err
-			}
-			if _, err := h.Write(nul); err != nil {
-				return err
+			parts := [][]byte{[]byte(relPath), nul, []byte("symlink:" + linkTarget), nul}
+			for _, part := range parts {
+				if _, err := h.Write(part); err != nil {
+					return hasherErr(err)
+				}
 			}
 		}
 

--- a/internal/myks/hashutil.go
+++ b/internal/myks/hashutil.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
+	"io/fs"
 	"os"
+	"path/filepath"
 
 	"github.com/rs/zerolog/log"
 )
@@ -35,5 +37,46 @@ func hashFile(filePath string) (string, error) {
 		return "", fmt.Errorf("failed to read file: %w", err)
 	}
 
+	return fmt.Sprintf("%x", h.Sum64()), nil
+}
+
+// hashDirectory computes a deterministic FNV-1a 64-bit hash of an entire
+// directory tree. It visits files in lexicographic order and includes the
+// relative path of each file in the hash so that renames are detected.
+// Symlinks and non-regular files are skipped.
+func hashDirectory(dirPath string) (string, error) {
+	h := fnv.New64a()
+	err := filepath.WalkDir(dirPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		relPath, err := filepath.Rel(dirPath, path)
+		if err != nil {
+			return err
+		}
+		// Include relative path so that file renames/moves change the hash.
+		if _, err := h.Write([]byte(relPath)); err != nil {
+			return err
+		}
+		file, err := os.Open(filepath.Clean(path))
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if closeErr := file.Close(); closeErr != nil {
+				log.Error().Err(closeErr).Msg("Failed to close file")
+			}
+		}()
+		if _, err := io.Copy(h, file); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to hash directory: %w", err)
+	}
 	return fmt.Sprintf("%x", h.Sum64()), nil
 }

--- a/internal/myks/hashutil.go
+++ b/internal/myks/hashutil.go
@@ -78,7 +78,7 @@ func hashDirectory(dirPath string) (string, error) {
 		if err != nil {
 			return fmt.Errorf("getting info for %s: %w", relPath, err)
 		}
-		mode := []byte(fmt.Sprintf("%o", info.Mode().Perm()))
+		mode := fmt.Appendf(nil, "%o", info.Mode().Perm())
 
 		switch {
 		case d.IsDir():

--- a/internal/myks/hashutil.go
+++ b/internal/myks/hashutil.go
@@ -56,7 +56,18 @@ func hashDirectory(dirPath string) (string, error) {
 	hasherErr := func(err error) error {
 		return fmt.Errorf("writing to hasher: %w", err)
 	}
-	err := filepath.WalkDir(dirPath, func(path string, d fs.DirEntry, err error) error {
+
+	root, err := os.OpenRoot(dirPath)
+	if err != nil {
+		return "", fmt.Errorf("opening root directory %s: %w", dirPath, err)
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			log.Error().Err(closeErr).Msg("Failed to close root directory")
+		}
+	}()
+
+	err = filepath.WalkDir(dirPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -76,9 +87,9 @@ func hashDirectory(dirPath string) (string, error) {
 			if _, err := h.Write(nul); err != nil {
 				return hasherErr(err)
 			}
-			file, err := os.Open(path)
+			file, err := root.Open(relPath)
 			if err != nil {
-				return fmt.Errorf("opening file %s: %w", path, err)
+				return fmt.Errorf("opening file %s: %w", relPath, err)
 			}
 			defer func() {
 				if closeErr := file.Close(); closeErr != nil {
@@ -96,9 +107,9 @@ func hashDirectory(dirPath string) (string, error) {
 			// Hash: relPath NUL "symlink:" linkTarget NUL
 			// We hash the link target string rather than following it to avoid
 			// infinite loops on circular symlinks.
-			linkTarget, err := os.Readlink(path)
+			linkTarget, err := root.Readlink(relPath)
 			if err != nil {
-				return fmt.Errorf("reading link %s: %w", path, err)
+				return fmt.Errorf("reading link %s: %w", relPath, err)
 			}
 			parts := [][]byte{[]byte(relPath), nul, []byte("symlink:" + linkTarget), nul}
 			for _, part := range parts {

--- a/internal/myks/hashutil.go
+++ b/internal/myks/hashutil.go
@@ -78,6 +78,12 @@ func hashDirectory(dirPath string) (string, error) {
 			return fmt.Errorf("getting relative path for %s: %w", path, err)
 		}
 
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("getting info for %s: %w", relPath, err)
+		}
+		mode := []byte(fmt.Sprintf("%o", info.Mode().Perm()))
+
 		switch {
 		case d.IsDir():
 			// Skip the root itself; all other directories are hashed by path so
@@ -85,16 +91,25 @@ func hashDirectory(dirPath string) (string, error) {
 			if relPath == "." {
 				return nil
 			}
-			// Hash: relPath NUL "dir" NUL
-			for _, part := range [][]byte{[]byte(relPath), nul, []byte("dir"), nul} {
+			// Hash: relPath NUL "dir" NUL mode NUL
+			for _, part := range [][]byte{[]byte(relPath), nul, []byte("dir"), nul, mode, nul} {
 				if _, err := h.Write(part); err != nil {
 					return hasherErr(err)
 				}
 			}
 
 		case d.Type().IsRegular():
-			// Hash: relPath NUL file-content NUL
+			// Hash: relPath NUL mode NUL file-content NUL
+			// Mode is included so that permission-only changes (e.g. chmod +x)
+			// invalidate the hash — important for Docker build contexts where
+			// the executable bit affects the resulting image.
 			if _, err := h.Write([]byte(relPath)); err != nil {
+				return hasherErr(err)
+			}
+			if _, err := h.Write(nul); err != nil {
+				return hasherErr(err)
+			}
+			if _, err := h.Write(mode); err != nil {
 				return hasherErr(err)
 			}
 			if _, err := h.Write(nul); err != nil {
@@ -117,14 +132,14 @@ func hashDirectory(dirPath string) (string, error) {
 			}
 
 		case d.Type()&fs.ModeSymlink != 0:
-			// Hash: relPath NUL "symlink:" linkTarget NUL
+			// Hash: relPath NUL "symlink:" linkTarget NUL mode NUL
 			// We hash the link target string rather than following it to avoid
 			// infinite loops on circular symlinks.
 			linkTarget, err := root.Readlink(relPath)
 			if err != nil {
 				return fmt.Errorf("reading link %s: %w", relPath, err)
 			}
-			parts := [][]byte{[]byte(relPath), nul, []byte("symlink:" + linkTarget), nul}
+			parts := [][]byte{[]byte(relPath), nul, []byte("symlink:" + linkTarget), nul, mode, nul}
 			for _, part := range parts {
 				if _, err := h.Write(part); err != nil {
 					return hasherErr(err)

--- a/internal/myks/hashutil.go
+++ b/internal/myks/hashutil.go
@@ -54,7 +54,7 @@ var nul = []byte{0}
 func hashDirectory(dirPath string) (string, error) {
 	h := fnv.New64a()
 	hasherErr := func(err error) error {
-		return fmt.Errorf("writing to hasher: %w", err)
+		return fmt.Errorf("hashing directory %s: %w", dirPath, err)
 	}
 
 	root, err := os.OpenRoot(dirPath)

--- a/internal/myks/hashutil.go
+++ b/internal/myks/hashutil.go
@@ -40,39 +40,76 @@ func hashFile(filePath string) (string, error) {
 	return fmt.Sprintf("%x", h.Sum64()), nil
 }
 
+// nul is a single NUL byte used as an unambiguous field separator in hashes.
+// Writing it between the relative path and file content prevents collisions
+// that would otherwise occur when one path is a prefix of another plus content
+// (e.g. path="ab" content="cd" vs path="abc" content="d").
+var nul = []byte{0}
+
 // hashDirectory computes a deterministic FNV-1a 64-bit hash of an entire
-// directory tree. It visits files in lexicographic order and includes the
-// relative path of each file in the hash so that renames are detected.
-// Symlinks and non-regular files are skipped.
+// directory tree. It visits entries in lexicographic order and includes the
+// relative path in the hash so that renames are detected. Regular files are
+// hashed by content; symlinks are hashed by their link target (not followed,
+// to avoid circular-link issues). Other non-regular entries are skipped.
 func hashDirectory(dirPath string) (string, error) {
 	h := fnv.New64a()
 	err := filepath.WalkDir(dirPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !d.Type().IsRegular() {
-			return nil
-		}
+
 		relPath, err := filepath.Rel(dirPath, path)
 		if err != nil {
 			return err
 		}
-		// Include relative path so that file renames/moves change the hash.
-		if _, err := h.Write([]byte(relPath)); err != nil {
-			return err
-		}
-		file, err := os.Open(filepath.Clean(path))
-		if err != nil {
-			return err
-		}
-		defer func() {
-			if closeErr := file.Close(); closeErr != nil {
-				log.Error().Err(closeErr).Msg("Failed to close file")
+
+		switch {
+		case d.Type().IsRegular():
+			// Hash: relPath NUL file-content NUL
+			if _, err := h.Write([]byte(relPath)); err != nil {
+				return err
 			}
-		}()
-		if _, err := io.Copy(h, file); err != nil {
-			return err
+			if _, err := h.Write(nul); err != nil {
+				return err
+			}
+			file, err := os.Open(filepath.Clean(path))
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if closeErr := file.Close(); closeErr != nil {
+					log.Error().Err(closeErr).Msg("Failed to close file")
+				}
+			}()
+			if _, err := io.Copy(h, file); err != nil {
+				return err
+			}
+			if _, err := h.Write(nul); err != nil {
+				return err
+			}
+
+		case d.Type()&fs.ModeSymlink != 0:
+			// Hash: relPath NUL "symlink:" linkTarget NUL
+			// We hash the link target string rather than following it to avoid
+			// infinite loops on circular symlinks.
+			linkTarget, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			if _, err := h.Write([]byte(relPath)); err != nil {
+				return err
+			}
+			if _, err := h.Write(nul); err != nil {
+				return err
+			}
+			if _, err := h.Write([]byte("symlink:" + linkTarget)); err != nil {
+				return err
+			}
+			if _, err := h.Write(nul); err != nil {
+				return err
+			}
 		}
+
 		return nil
 	})
 	if err != nil {

--- a/internal/myks/hashutil_test.go
+++ b/internal/myks/hashutil_test.go
@@ -1,0 +1,99 @@
+package myks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashDirectory_Determinism(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("world"), 0o600))
+
+	h1, err := hashDirectory(dir)
+	require.NoError(t, err)
+	h2, err := hashDirectory(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, h1, h2, "same directory should produce the same hash each time")
+}
+
+func TestHashDirectory_ContentChange(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "file.txt")
+	require.NoError(t, os.WriteFile(file, []byte("original"), 0o600))
+
+	h1, err := hashDirectory(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(file, []byte("modified"), 0o600))
+	h2, err := hashDirectory(dir)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, h1, h2, "modifying a file should change the hash")
+}
+
+func TestHashDirectory_FileAddition(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0o600))
+
+	h1, err := hashDirectory(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("new"), 0o600))
+	h2, err := hashDirectory(dir)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, h1, h2, "adding a file should change the hash")
+}
+
+func TestHashDirectory_FileDeletion(t *testing.T) {
+	dir := t.TempDir()
+	fileA := filepath.Join(dir, "a.txt")
+	fileB := filepath.Join(dir, "b.txt")
+	require.NoError(t, os.WriteFile(fileA, []byte("hello"), 0o600))
+	require.NoError(t, os.WriteFile(fileB, []byte("world"), 0o600))
+
+	h1, err := hashDirectory(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, os.Remove(fileB))
+	h2, err := hashDirectory(dir)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, h1, h2, "removing a file should change the hash")
+}
+
+func TestHashDirectory_FileRename(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "original.txt"), []byte("content"), 0o600))
+
+	h1, err := hashDirectory(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, os.Rename(
+		filepath.Join(dir, "original.txt"),
+		filepath.Join(dir, "renamed.txt"),
+	))
+	h2, err := hashDirectory(dir)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, h1, h2, "renaming a file should change the hash")
+}
+
+func TestHashDirectory_EmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	h, err := hashDirectory(dir)
+	require.NoError(t, err)
+	assert.NotEmpty(t, h, "empty directory should return a valid (non-empty) hash string")
+}
+
+func TestHashDirectory_NonExistentDirectory(t *testing.T) {
+	_, err := hashDirectory("/does/not/exist/at/all")
+	assert.Error(t, err, "non-existent directory should return an error")
+}

--- a/internal/myks/hashutil_test.go
+++ b/internal/myks/hashutil_test.go
@@ -97,3 +97,28 @@ func TestHashDirectory_NonExistentDirectory(t *testing.T) {
 	_, err := hashDirectory("/does/not/exist/at/all")
 	assert.Error(t, err, "non-existent directory should return an error")
 }
+
+func TestHashDirectory_SymlinkChange(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create two targets the symlink can point to.
+	target1 := filepath.Join(dir, "target1.txt")
+	target2 := filepath.Join(dir, "target2.txt")
+	require.NoError(t, os.WriteFile(target1, []byte("v1"), 0o600))
+	require.NoError(t, os.WriteFile(target2, []byte("v2"), 0o600))
+
+	link := filepath.Join(dir, "link.txt")
+	require.NoError(t, os.Symlink(target1, link))
+
+	h1, err := hashDirectory(dir)
+	require.NoError(t, err)
+
+	// Re-point the symlink to a different target.
+	require.NoError(t, os.Remove(link))
+	require.NoError(t, os.Symlink(target2, link))
+
+	h2, err := hashDirectory(dir)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, h1, h2, "changing a symlink target should change the hash")
+}

--- a/internal/myks/render_kbld.go
+++ b/internal/myks/render_kbld.go
@@ -1,6 +1,7 @@
 package myks
 
 import (
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -325,7 +326,7 @@ func extractKbldSourcePaths(previousStepFile string) ([]string, error) {
 	for {
 		var doc kbldSourceConfig
 		if err := decoder.Decode(&doc); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			// Log a warning but continue — some documents may not conform to

--- a/internal/myks/render_kbld.go
+++ b/internal/myks/render_kbld.go
@@ -1,7 +1,6 @@
 package myks
 
 import (
-	"bytes"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -303,10 +302,15 @@ func (k *Kbld) getLockFileName(overridesFilePath string, sourcesDirPaths []strin
 // step output) and returns the deduplicated, sorted list of `sources[].path`
 // values from kbld Config documents.
 func extractKbldSourcePaths(previousStepFile string) ([]string, error) {
-	data, err := os.ReadFile(filepath.Clean(previousStepFile))
+	file, err := os.Open(filepath.Clean(previousStepFile))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %w", err)
+		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			log.Error().Err(closeErr).Msg("Failed to close file")
+		}
+	}()
 
 	type kbldSourceConfig struct {
 		APIVersion string `yaml:"apiVersion"`
@@ -317,14 +321,16 @@ func extractKbldSourcePaths(previousStepFile string) ([]string, error) {
 	}
 
 	var paths []string
-	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder := yaml.NewDecoder(file)
 	for {
 		var doc kbldSourceConfig
 		if err := decoder.Decode(&doc); err != nil {
 			if err == io.EOF {
 				break
 			}
-			// Skip unparseable documents.
+			// Log a warning but continue — some documents may not conform to
+			// our struct (e.g. Kubernetes resources with complex nested types).
+			log.Warn().Err(err).Str("file", previousStepFile).Msg("Failed to decode YAML document while extracting kbld source paths")
 			continue
 		}
 		if doc.APIVersion != "kbld.k14s.io/v1alpha1" || doc.Kind != "Config" {

--- a/internal/myks/render_kbld.go
+++ b/internal/myks/render_kbld.go
@@ -1,9 +1,13 @@
 package myks
 
 import (
+	"bytes"
 	"fmt"
+	"hash/fnv"
+	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -88,11 +92,15 @@ func (k *Kbld) Render(previousStepFile string) (string, error) {
 
 	// if cache is enabled, check existence of the lock file and include it in the args
 	if config.Cache {
-		// The lock file name is based on the hash of the overrides file (if any).
-		// Since the lock file is also used as a digest resolution cache, this forces
-		// kbld to re-resolve images if the overrides change. Otherwise, the new overrides
-		// might not be applied if the images are already resolved and cached in the lock file.
-		lockFileName := k.getLockFileName(overridesFilePath)
+		// The lock file name is based on the hash of the overrides file (if any) and the
+		// hash of any kbld source directories (if any). This forces kbld to re-resolve
+		// images when either the overrides or the build context changes.
+		sourcesDirPaths, err := extractKbldSourcePaths(previousStepFile)
+		if err != nil {
+			log.Warn().Err(err).Msg(k.app.Msg(k.getStepName(), "Unable to extract kbld source paths"))
+			sourcesDirPaths = nil
+		}
+		lockFileName := k.getLockFileName(overridesFilePath, sourcesDirPaths)
 		lockFilePath := k.app.expandServicePath(lockFileName)
 
 		defer k.cleanupLockFiles(lockFileName)
@@ -255,18 +263,83 @@ func (k *Kbld) generateKbldOverrideConfig(overrides map[string]string) (string, 
 	return filename, err
 }
 
-func (k *Kbld) getLockFileName(overridesFilePath string) string {
+func (k *Kbld) getLockFileName(overridesFilePath string, sourcesDirPaths []string) string {
 	// This is the FNV-1a 64-bit hash of an empty string ("").
 	// It serves as the default hash value when no overrides file exists.
-	hash := "cbf29ce484222325"
+	overridesHash := "cbf29ce484222325"
 	if overridesFilePath != "" {
 		if data, err := hashFile(overridesFilePath); err == nil {
-			hash = data
+			overridesHash = data
 		} else {
 			log.Warn().Err(err).Msg(k.app.Msg(k.getStepName(), "Unable to hash overrides file for lock file naming"))
 		}
 	}
-	return fmt.Sprintf("%s%s.yaml", kbldLockFilePrefix, hash)
+
+	// If no source directories, use existing single-hash format for backward compatibility.
+	if len(sourcesDirPaths) == 0 {
+		return fmt.Sprintf("%s%s.yaml", kbldLockFilePrefix, overridesHash)
+	}
+
+	// Combine per-directory hashes into a single sources hash.
+	sourcesHasher := fnv.New64a()
+	for _, dir := range sourcesDirPaths {
+		dirHash, err := hashDirectory(dir)
+		if err != nil {
+			log.Warn().Err(err).Str("dir", dir).Msg(
+				k.app.Msg(k.getStepName(), "Unable to hash source directory, skipping"))
+			continue
+		}
+		if _, err := sourcesHasher.Write([]byte(dirHash)); err != nil {
+			log.Warn().Err(err).Str("dir", dir).Msg(
+				k.app.Msg(k.getStepName(), "Unable to update sources hash, skipping"))
+		}
+	}
+	sourcesHash := fmt.Sprintf("%x", sourcesHasher.Sum64())
+
+	return fmt.Sprintf("%s%s-%s.yaml", kbldLockFilePrefix, overridesHash, sourcesHash)
+}
+
+// extractKbldSourcePaths parses a multi-document YAML file (the previous render
+// step output) and returns the deduplicated, sorted list of `sources[].path`
+// values from kbld Config documents.
+func extractKbldSourcePaths(previousStepFile string) ([]string, error) {
+	data, err := os.ReadFile(filepath.Clean(previousStepFile))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	type kbldSourceConfig struct {
+		APIVersion string `yaml:"apiVersion"`
+		Kind       string `yaml:"kind"`
+		Sources    []struct {
+			Path string `yaml:"path"`
+		} `yaml:"sources"`
+	}
+
+	var paths []string
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	for {
+		var doc kbldSourceConfig
+		if err := decoder.Decode(&doc); err != nil {
+			if err == io.EOF {
+				break
+			}
+			// Skip unparseable documents.
+			continue
+		}
+		if doc.APIVersion != "kbld.k14s.io/v1alpha1" || doc.Kind != "Config" {
+			continue
+		}
+		for _, src := range doc.Sources {
+			if src.Path != "" {
+				paths = append(paths, src.Path)
+			}
+		}
+	}
+
+	sort.Strings(paths)
+	paths = slices.Compact(paths)
+	return paths, nil
 }
 
 func (k *Kbld) cleanupLockFiles(leaveFile string) {

--- a/internal/myks/render_kbld.go
+++ b/internal/myks/render_kbld.go
@@ -292,6 +292,11 @@ func (k *Kbld) getLockFileName(overridesFilePath string, sourcesDirPaths []strin
 		if _, err := sourcesHasher.Write([]byte(dirHash)); err != nil {
 			log.Warn().Err(err).Str("dir", dir).Msg(
 				k.app.Msg(k.getStepName(), "Unable to update sources hash, skipping"))
+			continue
+		}
+		if _, err := sourcesHasher.Write(nul); err != nil {
+			log.Warn().Err(err).Str("dir", dir).Msg(
+				k.app.Msg(k.getStepName(), "Unable to update sources hash separator, skipping"))
 		}
 	}
 	sourcesHash := fmt.Sprintf("%x", sourcesHasher.Sum64())

--- a/internal/myks/render_kbld.go
+++ b/internal/myks/render_kbld.go
@@ -344,7 +344,7 @@ func extractKbldSourcePaths(previousStepFile string) ([]string, error) {
 		}
 		for _, src := range doc.Sources {
 			if src.Path != "" {
-				paths = append(paths, src.Path)
+				paths = append(paths, filepath.Clean(src.Path))
 			}
 		}
 	}

--- a/internal/myks/render_kbld_test.go
+++ b/internal/myks/render_kbld_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -248,4 +251,166 @@ func TestKbld_generateKbldOverrideConfig_Consistency(t *testing.T) {
 			t.Errorf("Output %d differs from the first output\nFirst:\n%s\n\nOutput %d:\n%s", i+1, firstOutput, i+1, output)
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests for extractKbldSourcePaths
+// ---------------------------------------------------------------------------
+
+func TestExtractKbldSourcePaths_WithSources(t *testing.T) {
+	content := `
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+sources:
+  - path: /tmp/myapp
+  - path: /tmp/otherapp
+`
+	f := writeTempFile(t, content)
+	paths, err := extractKbldSourcePaths(f)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/tmp/myapp", "/tmp/otherapp"}, paths)
+}
+
+func TestExtractKbldSourcePaths_WithoutSources(t *testing.T) {
+	content := `
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+overrides:
+  - image: nginx
+    newImage: my-registry/nginx
+`
+	f := writeTempFile(t, content)
+	paths, err := extractKbldSourcePaths(f)
+	require.NoError(t, err)
+	assert.Empty(t, paths)
+}
+
+func TestExtractKbldSourcePaths_NonKbldDocumentsSkipped(t *testing.T) {
+	content := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+`
+	f := writeTempFile(t, content)
+	paths, err := extractKbldSourcePaths(f)
+	require.NoError(t, err)
+	assert.Empty(t, paths)
+}
+
+func TestExtractKbldSourcePaths_MultiDocMixedTypes(t *testing.T) {
+	content := strings.Join([]string{
+		`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp`,
+		`apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+sources:
+  - path: /build/context`,
+		`apiVersion: v1
+kind: Service
+metadata:
+  name: myapp`,
+	}, "\n---\n")
+	f := writeTempFile(t, content)
+	paths, err := extractKbldSourcePaths(f)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/build/context"}, paths)
+}
+
+func TestExtractKbldSourcePaths_EmptyFile(t *testing.T) {
+	f := writeTempFile(t, "")
+	paths, err := extractKbldSourcePaths(f)
+	require.NoError(t, err)
+	assert.Empty(t, paths)
+}
+
+func TestExtractKbldSourcePaths_Deduplicated(t *testing.T) {
+	content := strings.Join([]string{
+		`apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+sources:
+  - path: /build/ctx
+  - path: /build/ctx`,
+		`apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+sources:
+  - path: /build/ctx`,
+	}, "\n---\n")
+	f := writeTempFile(t, content)
+	paths, err := extractKbldSourcePaths(f)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/build/ctx"}, paths)
+}
+
+// ---------------------------------------------------------------------------
+// Tests for getLockFileName
+// ---------------------------------------------------------------------------
+
+func newTestKbld(t *testing.T) *Kbld {
+	t.Helper()
+	tmpDir := t.TempDir()
+	globe := &Globe{Config: Config{RootDir: tmpDir}}
+	env := &Environment{ID: "test-env", g: globe, cfg: &globe.Config, Dir: tmpDir}
+	app := &Application{Name: "test-app", Prototype: "test-proto", e: env, cfg: &globe.Config}
+	return &Kbld{ident: "test", app: app}
+}
+
+func TestGetLockFileName_NoOverridesNoSources(t *testing.T) {
+	k := newTestKbld(t)
+	name := k.getLockFileName("", nil)
+	// Must use the legacy single-hash format with the FNV-1a hash of ""
+	assert.Equal(t, "kbld-lock-cbf29ce484222325.yaml", name)
+}
+
+func TestGetLockFileName_OverridesNoSources(t *testing.T) {
+	k := newTestKbld(t)
+	f := writeTempFile(t, "some: overrides")
+	name := k.getLockFileName(f, nil)
+	// Single-hash format (backward compat) — hash is non-default
+	assert.True(t, strings.HasPrefix(name, "kbld-lock-"), "should start with kbld-lock-")
+	assert.True(t, strings.HasSuffix(name, ".yaml"), "should end with .yaml")
+	parts := strings.Split(strings.TrimSuffix(strings.TrimPrefix(name, "kbld-lock-"), ".yaml"), "-")
+	assert.Len(t, parts, 1, "without sources there should be only one hash segment")
+	assert.NotEqual(t, "cbf29ce484222325", parts[0], "hash should differ from the empty-string default")
+}
+
+func TestGetLockFileName_OverridesAndSources(t *testing.T) {
+	k := newTestKbld(t)
+	overridesFile := writeTempFile(t, "some: overrides")
+
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "Dockerfile"), []byte("FROM alpine"), 0o600))
+
+	name := k.getLockFileName(overridesFile, []string{srcDir})
+	assert.True(t, strings.HasPrefix(name, "kbld-lock-"), "should start with kbld-lock-")
+	assert.True(t, strings.HasSuffix(name, ".yaml"), "should end with .yaml")
+	parts := strings.Split(strings.TrimSuffix(strings.TrimPrefix(name, "kbld-lock-"), ".yaml"), "-")
+	assert.Len(t, parts, 2, "with sources there should be two hash segments separated by '-'")
+}
+
+func TestGetLockFileName_SourcesNoOverrides(t *testing.T) {
+	k := newTestKbld(t)
+
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "app.go"), []byte("package main"), 0o600))
+
+	name := k.getLockFileName("", []string{srcDir})
+	assert.True(t, strings.HasPrefix(name, "kbld-lock-"), "should start with kbld-lock-")
+	parts := strings.Split(strings.TrimSuffix(strings.TrimPrefix(name, "kbld-lock-"), ".yaml"), "-")
+	assert.Len(t, parts, 2, "with sources there should be two hash segments")
+	// First segment is the default overrides hash (empty string hash)
+	assert.Equal(t, "cbf29ce484222325", parts[0])
+}
+
+// writeTempFile is a test helper that writes content to a temp file and returns its path.
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "kbld-test-*.yaml")
+	require.NoError(t, err)
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
 }

--- a/internal/myks/render_kbld_test.go
+++ b/internal/myks/render_kbld_test.go
@@ -327,17 +327,16 @@ func TestExtractKbldSourcePaths_EmptyFile(t *testing.T) {
 }
 
 func TestExtractKbldSourcePaths_Deduplicated(t *testing.T) {
-	content := strings.Join([]string{
-		`apiVersion: kbld.k14s.io/v1alpha1
+	content := `apiVersion: kbld.k14s.io/v1alpha1
 kind: Config
 sources:
   - path: /build/ctx
-  - path: /build/ctx`,
-		`apiVersion: kbld.k14s.io/v1alpha1
+  - path: /build/ctx
+---
+apiVersion: kbld.k14s.io/v1alpha1
 kind: Config
 sources:
-  - path: /build/ctx`,
-	}, "\n---\n")
+  - path: /build/ctx`
 	f := writeTempFile(t, content)
 	paths, err := extractKbldSourcePaths(f)
 	require.NoError(t, err)

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -6,11 +6,15 @@ pkgs.mkShell {
     go-task
     gofumpt
     goimports-reviser
-    golangci-lint
     goreleaser
     gosec
     lefthook
+    mise
     nix-update
     upx
   ];
+  shellHook = ''
+    mise install
+    source <(mise activate)
+  '';
 }


### PR DESCRIPTION
## Summary

- The kbld lock file name is now derived from both the overrides file hash **and** a hash of any `sources` directories declared in kbld `Config` documents in the previous render step output.
- Apps without `sources` (the vast majority) get the exact same single-hash lock filename as before — no cache misses.
- Apps with `sources` get a two-segment filename (`kbld-lock-<overridesHash>-<sourcesHash>.yaml`); the first render after upgrading will trigger one cache miss and rebuild, after which the cache works normally.

## Test plan

- [x] `TestHashDirectory_*` — 7 unit tests covering determinism, content/rename/add/delete sensitivity, empty dir, and missing dir
- [x] `TestExtractKbldSourcePaths_*` — 6 unit tests covering sources extraction, multi-doc YAML, skipping non-kbld docs, deduplication, and empty file
- [x] `TestGetLockFileName_*` — 4 unit tests verifying backward-compat (no sources → single hash), sources present → two-part hash
- [x] All existing `TestKbld_*` tests continue to pass

## Manual verification (on myks-homelab)

1. Render `cams` — observe two-part lock file name
2. Modify `prototypes/maks-cams/docker/assets/app.js` — re-render — observe different lock file name and kbld rebuild
3. Render `echo` (no sources) — verify lock file name unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)