### PR TITLE
feat: myks KCL schema package with eval-time version assert

### DIFF
--- a/.github/workflows/flow-kcl-package.yml
+++ b/.github/workflows/flow-kcl-package.yml
@@ -1,0 +1,37 @@
+name: flow-kcl-package
+
+# Publishes the myks KCL schema package (kcl/myks) to the OCI registry.
+# The tag is the version in kcl/myks/kcl.mod; pushing an existing version overwrites it.
+'on':
+  push:
+    branches:
+      - main
+    paths:
+      - kcl/myks/**
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Publish KCL package
+        env:
+          KCL_CLI_VERSION: v0.12.4 # keep in lockstep with kcl-lang.io/kcl-go in go.mod
+        run: |
+          go install kcl-lang.io/cli/cmd/kcl@$KCL_CLI_VERSION
+          echo '${{ secrets.GITHUB_TOKEN }}' \
+            | kcl registry login -u '${{ github.actor }}' --password-stdin ghcr.io
+          cd kcl/myks
+          kcl mod push oci://ghcr.io/mykso/myks

--- a/.github/workflows/flow-kcl-package.yml
+++ b/.github/workflows/flow-kcl-package.yml
@@ -1,13 +1,13 @@
 name: flow-kcl-package
 
 # Publishes the myks KCL schema package (kcl/myks) to the OCI registry.
-# The tag is the version in kcl/myks/kcl.mod; pushing an existing version overwrites it.
+# The tag is the version in kcl/myks/kcl.mod. Bump it for every package change.
 'on':
   push:
     branches:
       - main
     paths:
-      - kcl/myks/**
+      - kcl/myks/kcl.mod
 
 jobs:
   publish:

--- a/examples/kcl-skeleton/README.md
+++ b/examples/kcl-skeleton/README.md
@@ -4,6 +4,9 @@ Minimal repo exercising the KCL-based configuration layer ([design](../../docs/r
 at the root selects KCL mode: myks evaluates the KCL module into a frozen resolved tree and discovers environments and
 applications from it — no filesystem walk, no ytt data-values authoring.
 
+- `kcl.mod` depends on the [myks schema package](../../kcl/myks) (`Environment`, `App`, `finalize`,
+  `SCHEMA_VERSION`) — by path here so the example tracks the engine at HEAD; user repos pin the
+  published package with `kcl mod add oci://ghcr.io/mykso/myks`
 - `main.k` emits the frozen tree (`myksSchemaVersion`, `environments`)
 - `envs/env.k` holds global defaults and the shared application roster
 - `envs/dev/env.k` and `envs/prod/env.k` import the base level and patch it
@@ -22,7 +25,7 @@ Smart Mode is not supported in KCL mode: a plain `myks render` warns and renders
 
 ```
 .
-├── kcl.mod                # KCL module manifest; the KCL-mode marker
+├── kcl.mod                # KCL module manifest; the KCL-mode marker; pins the myks schema package
 ├── main.k                 # root evaluation: emits the frozen resolved tree
 ├── envs
 │   ├── env.k              # base level: defaults + application roster

--- a/examples/kcl-skeleton/envs/dev/env.k
+++ b/examples/kcl-skeleton/envs/dev/env.k
@@ -1,7 +1,9 @@
+import myks
+
 import envs
 
-env = envs.env | {
+env = myks.finalize(envs.env | {
     id = "kcl-dev"
     applications.hello.application.greeting = "hello from dev"
     applications.hello.helm.namespace = "dev-hello"
-}
+})

--- a/examples/kcl-skeleton/envs/env.k
+++ b/examples/kcl-skeleton/envs/env.k
@@ -1,8 +1,10 @@
 # Base level: global defaults and the shared application roster.
 # Leaf environments import this package and patch it.
-env = {
+import myks
+
+env = myks.Environment {
     argocd.enabled = False
-    applications.hello = {
+    applications.hello = myks.App {
         proto = "hello"
         argocd.enabled = False
         application.greeting = "hello"

--- a/examples/kcl-skeleton/envs/prod/env.k
+++ b/examples/kcl-skeleton/envs/prod/env.k
@@ -1,6 +1,8 @@
+import myks
+
 import envs
 
-env = envs.env | {
+env = myks.finalize(envs.env | {
     id = "kcl-prod"
     applications.hello.helm.namespace = "prod-hello"
-}
+})

--- a/examples/kcl-skeleton/kcl.mod
+++ b/examples/kcl-skeleton/kcl.mod
@@ -1,3 +1,9 @@
 [package]
 name = "config"
 version = "0.1.0"
+
+# In-repo example: the myks schema package is consumed by path so the example
+# always tracks the engine at HEAD. User repos pin the published package instead:
+#   kcl mod add oci://ghcr.io/mykso/myks
+[dependencies]
+myks = { path = "../../kcl/myks" }

--- a/examples/kcl-skeleton/kcl.mod.lock
+++ b/examples/kcl-skeleton/kcl.mod.lock
@@ -1,0 +1,5 @@
+[dependencies]
+  [dependencies.myks]
+    name = "myks"
+    full_name = "myks_0.1.0"
+    version = "0.1.0"

--- a/examples/kcl-skeleton/main.k
+++ b/examples/kcl-skeleton/main.k
@@ -1,9 +1,11 @@
 # Root evaluation: emits the frozen resolved tree consumed by myks.
 # Environments are discovered from this output only — no filesystem walk.
+import myks
+
 import envs.dev
 import envs.prod
 
-myksSchemaVersion = "0.1.0"
+myksSchemaVersion = myks.SCHEMA_VERSION
 environments = {
     dev = dev.env
     prod = prod.env

--- a/internal/myks/kcl.go
+++ b/internal/myks/kcl.go
@@ -20,6 +20,10 @@ const (
 	kclGeneratedAppDataFileName = "app-data.kcl-generated.ytt.yaml"
 )
 
+// supportedKclSchemaVersion is the myks schema version the engine understands.
+// Kept in lockstep with kcl/myks/version.k; compatibility is same major.minor.
+const supportedKclSchemaVersion = "0.1.0"
+
 // kclGeneratedAppDataHeader turns the resolved app config into a ytt schema-extension document.
 // A schema doc (not a plain data-values doc) is used so that keys unknown to the embedded
 // data schema (e.g. prototype-specific `application` values) are accepted.
@@ -69,7 +73,21 @@ func (g *Globe) loadKclTree() (*kclTree, error) {
 
 // evalKclTree evaluates the KCL module at rootDir and parses the frozen resolved tree.
 func evalKclTree(rootDir string) (*kclTree, error) {
-	res, err := kcl.Run(rootDir)
+	// The resolver treats a relative manifest path as relative to its own cache dir, not the cwd.
+	absRootDir, err := filepath.Abs(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving absolute path of %s: %w", rootDir, err)
+	}
+	deps, err := kcl.UpdateDependencies(&kcl.UpdateDependenciesArgs{ManifestPath: absRootDir})
+	if err != nil {
+		return nil, fmt.Errorf("resolving KCL dependencies at %s: %w", rootDir, err)
+	}
+	opts := make([]kcl.Option, 0, len(deps.ExternalPkgs))
+	for _, pkg := range deps.ExternalPkgs {
+		opts = append(opts, kcl.WithExternalPkgAndPath(pkg.PkgName, pkg.PkgPath))
+	}
+
+	res, err := kcl.Run(rootDir, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("evaluating KCL config at %s: %w", rootDir, err)
 	}
@@ -82,7 +100,9 @@ func evalKclTree(rootDir string) (*kclTree, error) {
 	if tree.MyksSchemaVersion == "" {
 		return nil, fmt.Errorf("KCL evaluation output is missing myksSchemaVersion")
 	}
-	// ponytail: no version compatibility assert yet; wired in with the published schema package (roadmap step 2)
+	if err := checkKclSchemaVersion(tree.MyksSchemaVersion); err != nil {
+		return nil, err
+	}
 
 	// A nil map means the key is absent (an explicit empty mapping unmarshals to a non-nil map).
 	if tree.Environments == nil {
@@ -99,6 +119,29 @@ func evalKclTree(rootDir string) (*kclTree, error) {
 	}
 
 	return tree, nil
+}
+
+// checkKclSchemaVersion asserts the tree's schema version is compatible with the engine.
+// Compatible means same major.minor as supportedKclSchemaVersion; patch versions may differ.
+func checkKclSchemaVersion(version string) error {
+	majorMinor := func(v string) (string, bool) {
+		parts := strings.SplitN(v, ".", 3)
+		if len(parts) < 2 {
+			return "", false
+		}
+		return parts[0] + "." + parts[1], true
+	}
+	got, ok := majorMinor(version)
+	if !ok {
+		return fmt.Errorf("malformed myksSchemaVersion %q: expected a semver like %s", version, supportedKclSchemaVersion)
+	}
+	want, _ := majorMinor(supportedKclSchemaVersion)
+	if got != want {
+		return fmt.Errorf(
+			"unsupported myksSchemaVersion %s: this myks build supports %s.x — align the myks schema package pinned in kcl.mod with the myks version",
+			version, want)
+	}
+	return nil
 }
 
 // initFromKclTree initializes environments and applications from the frozen tree.

--- a/internal/myks/kcl.go
+++ b/internal/myks/kcl.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	version "github.com/hashicorp/go-version"
 	"github.com/rs/zerolog/log"
 	yaml "gopkg.in/yaml.v3"
 	kcl "kcl-lang.io/kcl-go"
@@ -123,23 +124,22 @@ func evalKclTree(rootDir string) (*kclTree, error) {
 
 // checkKclSchemaVersion asserts the tree's schema version is compatible with the engine.
 // Compatible means same major.minor as supportedKclSchemaVersion; patch versions may differ.
-func checkKclSchemaVersion(version string) error {
-	majorMinor := func(v string) (string, bool) {
-		parts := strings.SplitN(v, ".", 3)
-		if len(parts) < 2 {
-			return "", false
-		}
-		return parts[0] + "." + parts[1], true
+func checkKclSchemaVersion(schemaVersion string) error {
+	parsed, err := version.NewSemver(schemaVersion)
+	core, _, _ := strings.Cut(schemaVersion, "+")
+	core, _, _ = strings.Cut(core, "-")
+	if err != nil || len(strings.Split(core, ".")) != 3 {
+		return fmt.Errorf("malformed myksSchemaVersion %q: expected a semver like %s", schemaVersion, supportedKclSchemaVersion)
 	}
-	got, ok := majorMinor(version)
-	if !ok {
-		return fmt.Errorf("malformed myksSchemaVersion %q: expected a semver like %s", version, supportedKclSchemaVersion)
+	want, err := version.NewSemver(supportedKclSchemaVersion)
+	if err != nil {
+		return fmt.Errorf("parsing supported KCL schema version %q: %w", supportedKclSchemaVersion, err)
 	}
-	want, _ := majorMinor(supportedKclSchemaVersion)
-	if got != want {
+	gotSegments, wantSegments := parsed.Segments(), want.Segments()
+	if gotSegments[0] != wantSegments[0] || gotSegments[1] != wantSegments[1] {
 		return fmt.Errorf(
 			"unsupported myksSchemaVersion %s: this myks build supports %s.x — align the myks schema package pinned in kcl.mod with the myks version",
-			version, want)
+			schemaVersion, fmt.Sprintf("%d.%d", wantSegments[0], wantSegments[1]))
 	}
 	return nil
 }

--- a/internal/myks/kcl_test.go
+++ b/internal/myks/kcl_test.go
@@ -99,6 +99,16 @@ func TestWriteKclAppDataFile(t *testing.T) {
 	assert.Contains(t, appConfig, "proto")
 }
 
+// TestCheckKclSchemaVersion verifies the engine's schema-version compatibility rule.
+func TestCheckKclSchemaVersion(t *testing.T) {
+	t.Parallel()
+	assert.NoError(t, checkKclSchemaVersion(supportedKclSchemaVersion))
+	assert.NoError(t, checkKclSchemaVersion("0.1.99"), "patch versions may differ")
+	assert.ErrorContains(t, checkKclSchemaVersion("0.2.0"), "unsupported myksSchemaVersion")
+	assert.ErrorContains(t, checkKclSchemaVersion("1.1.0"), "unsupported myksSchemaVersion")
+	assert.ErrorContains(t, checkKclSchemaVersion("nonsense"), "malformed myksSchemaVersion")
+}
+
 // TestEvalKclTree verifies evaluation and validation of a minimal KCL module.
 func TestEvalKclTree(t *testing.T) {
 	t.Parallel()
@@ -152,6 +162,42 @@ environments = {}
 		tree, err := evalKclTree(dir)
 		require.NoError(t, err)
 		assert.Empty(t, tree.Environments)
+	})
+
+	t.Run("incompatible schema version", func(t *testing.T) {
+		t.Parallel()
+		dir := writeModule(t, `
+myksSchemaVersion = "99.0.0"
+environments = {}
+`)
+		_, err := evalKclTree(dir)
+		assert.ErrorContains(t, err, "unsupported myksSchemaVersion 99.0.0")
+	})
+
+	t.Run("kcl.mod path dependency is resolved", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		depDir := filepath.Join(dir, "dep")
+		require.NoError(t, os.MkdirAll(depDir, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(depDir, "kcl.mod"),
+			[]byte("[package]\nname = \"dep\"\nversion = \"0.1.0\"\n"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(depDir, "main.k"),
+			[]byte(`VERSION = "0.1.0"`), 0o600))
+
+		modDir := filepath.Join(dir, "config")
+		require.NoError(t, os.MkdirAll(modDir, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(modDir, "kcl.mod"),
+			[]byte("[package]\nname = \"config\"\n\n[dependencies]\ndep = { path = \"../dep\" }\n"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(modDir, "main.k"), []byte(`
+import dep
+
+myksSchemaVersion = dep.VERSION
+environments = {}
+`), 0o600))
+
+		tree, err := evalKclTree(modDir)
+		require.NoError(t, err)
+		assert.Equal(t, "0.1.0", tree.MyksSchemaVersion)
 	})
 
 	t.Run("duplicate environment ids", func(t *testing.T) {

--- a/internal/myks/kcl_test.go
+++ b/internal/myks/kcl_test.go
@@ -107,6 +107,8 @@ func TestCheckKclSchemaVersion(t *testing.T) {
 	assert.ErrorContains(t, checkKclSchemaVersion("0.2.0"), "unsupported myksSchemaVersion")
 	assert.ErrorContains(t, checkKclSchemaVersion("1.1.0"), "unsupported myksSchemaVersion")
 	assert.ErrorContains(t, checkKclSchemaVersion("nonsense"), "malformed myksSchemaVersion")
+	assert.ErrorContains(t, checkKclSchemaVersion("0.1"), "malformed myksSchemaVersion")
+	assert.ErrorContains(t, checkKclSchemaVersion("0.1.0.1"), "malformed myksSchemaVersion")
 }
 
 // TestEvalKclTree verifies evaluation and validation of a minimal KCL module.

--- a/kcl/myks/README.md
+++ b/kcl/myks/README.md
@@ -1,0 +1,27 @@
+# myks KCL schema package
+
+Schemas for the myks KCL configuration layer ([design](../../docs/redesign/design.md)):
+
+- `Environment` — one node of the environment inheritance tree
+- `App` — resolved application configuration; the base for prototype schemas
+- `finalize` — leaf finalizer; validates leaf invariants (non-empty `id`)
+- `SCHEMA_VERSION` — stamped into the frozen tree as `myksSchemaVersion`; the myks engine
+  asserts compatibility (same major.minor) at eval time
+
+## Usage
+
+```sh
+kcl mod add oci://ghcr.io/mykso/myks
+```
+
+```kcl
+import myks
+
+env = myks.finalize(parent.env | {
+    id = "shop-prod-east"
+})
+```
+
+Published to `oci://ghcr.io/mykso/myks` by CI on changes to this directory
+(`.github/workflows/flow-kcl-package.yml`). Bump `version` in `kcl.mod` together with
+`SCHEMA_VERSION` in `version.k` and `supportedKclSchemaVersion` in the engine.

--- a/kcl/myks/finalize.k
+++ b/kcl/myks/finalize.k
@@ -1,0 +1,8 @@
+# Leaf finalizer: the single place leaf invariants are validated.
+# Derivations and checks that would fire on intermediate levels belong here,
+# not in schema `check` blocks (KCL re-evaluates those on every override).
+finalize = lambda env: Environment -> Environment {
+    # truthiness covers Undefined (attr never set), None and ""
+    assert env.id, "a leaf environment must set a non-empty id"
+    env
+}

--- a/kcl/myks/kcl.mod
+++ b/kcl/myks/kcl.mod
@@ -1,0 +1,5 @@
+[package]
+name = "myks"
+edition = "v0.12.4"
+version = "0.1.0"
+description = "myks configuration-layer schemas: Environment, App, finalize"

--- a/kcl/myks/schemas.k
+++ b/kcl/myks/schemas.k
@@ -1,0 +1,27 @@
+schema Environment:
+    """One node of the environment inheritance tree.
+
+    Intermediate levels leave `id` unset; a leaf sets it and passes through
+    `finalize`, which validates leaf invariants. No `check` block here:
+    validation must not fire on intermediate (not-yet-finalized) instances.
+
+    Extra keys (e.g. a `global` bag of shared values) are allowed and flow
+    into the frozen tree; the engine reads only `id`, `argocd` and
+    `applications`.
+    """
+    id?: str
+    argocd?: {str:any}
+    applications?: {str:App}
+    [...str]: any
+
+schema App:
+    """Resolved configuration of one Application; the base for prototype schemas.
+
+    `proto` selects the prototype (sync/render sources); it defaults to the
+    application's key in `applications` when unset. All other keys are the
+    app's resolved values, passed to the render pipeline as ytt data values.
+    Prototype packages subclass this to type their own values.
+    """
+    proto?: str
+    argocd?: {str:any}
+    [...str]: any

--- a/kcl/myks/version.k
+++ b/kcl/myks/version.k
@@ -1,0 +1,4 @@
+# The schema version stamped into the frozen tree (`myksSchemaVersion`).
+# The myks engine asserts compatibility (same major.minor) at eval time.
+# Keep in lockstep with `version` in kcl.mod and `supportedKclSchemaVersion` in the engine.
+SCHEMA_VERSION = "0.1.0"


### PR DESCRIPTION
**What**: myks KCL schema package (`kcl/myks`) published to OCI, engine-side schema-version assert, skeleton example consuming the package. Implements #879 (roadmap step 2).

**Why**: Formalize the config-layer schemas (`Environment`, `App`, `finalize`, `SCHEMA_VERSION`) so user repos pin them via `kcl.mod` and the engine fails fast on schema/engine version skew.

**How**:

- `kcl/myks`: schemas per design.md, respecting the bake-off papercuts — no `check` blocks on `Environment`/`App` (they'd fire on intermediates), leaf validation lives in `finalize`, no eagerly-instantiated nested defaults. `App` doubles as the prototype base schema.
- Engine: `evalKclTree` now resolves `kcl.mod` dependencies (`kcl.UpdateDependencies` → `WithExternalPkgAndPath`) before `kcl.Run`, and asserts `myksSchemaVersion` against `supportedKclSchemaVersion` (same major.minor; patch may differ). The manifest path is absolutized first — the resolver treats relative paths as relative to its cache dir, not cwd.
- Publishing: `flow-kcl-package.yml` pushes `kcl/myks` to `oci://ghcr.io/mykso/myks` on main when the directory changes (first publish happens when this merges).
- Skeleton example imports `myks.Environment` / `myks.App` / `myks.finalize`; rendered output is byte-identical.

**Notes for reviewer**:

- The example uses a **path** dependency (`myks = { path = "../../kcl/myks" }`), not the published OCI package: keeps CI hermetic and tests the schemas at HEAD instead of the last published version. User-facing OCI usage is documented in the package and example READMEs.
- Version now lives in three places (kcl.mod, version.k, Go const); each carries a lockstep comment.

Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)