### PR TITLE
feat: full KCL pipeline on a real fixture + byte-identical gate harness

### DIFF
--- a/examples/kcl-integration-tests/.myks.yaml
+++ b/examples/kcl-integration-tests/.myks.yaml
@@ -1,0 +1,7 @@
+---
+# Sets the number of applications to be processed in parallel.
+# The default (0) is no limit.
+async: 0
+# One of the zerolog log levels.
+# See: https://github.com/rs/zerolog#leveled-logging
+log-level: info

--- a/examples/kcl-integration-tests/README.md
+++ b/examples/kcl-integration-tests/README.md
@@ -1,0 +1,18 @@
+# Integration tests — KCL mode
+
+This is the [integration-tests](../integration-tests) fixture ported to the KCL configuration
+layer ([design](../../docs/redesign/design.md)). Prototypes, env-level ytt overlays, helm values
+templates and lib files are identical to the legacy fixture; all ytt data-values authoring
+(`env-data.ytt.yaml`, `app-data.ytt.yaml`) is replaced by the KCL tree:
+
+- `kcl.mod` selects KCL mode and pins the [myks schema package](../../kcl/myks) (by path here)
+- `main.k` emits the frozen resolved tree
+- `envs/env.k` carries the shared defaults and the application roster with root-level values
+- `envs/dev/env.k` is the leaf environment with dev-level overrides and derivations
+
+## The byte-identical gate
+
+`TestKclGate` (internal/integration) renders this repo and the legacy fixture and requires their
+`rendered/` trees to be byte-identical (modulo the repo path baked into ArgoCD source paths).
+It is the migration gate of the config-layer redesign and the test suite of the future
+`myks migrate` converter. When changing either fixture, keep the other in sync.

--- a/examples/kcl-integration-tests/envs/_apps/helm-installation/helm/render-test.quux.yaml
+++ b/examples/kcl-integration-tests/envs/_apps/helm-installation/helm/render-test.quux.yaml
@@ -1,0 +1,3 @@
+---
+outputYaml:
+  extraValuesAppQuux: true

--- a/examples/kcl-integration-tests/envs/_apps/helm-installation/helm/render-test.yaml
+++ b/examples/kcl-integration-tests/envs/_apps/helm-installation/helm/render-test.yaml
@@ -1,0 +1,5 @@
+#@ load("@ytt:data", "data")
+---
+outputYaml:
+  fromEnvGroup: true
+  fromEnvGroupAppData: #@ data.values.application.envGroupValue

--- a/examples/kcl-integration-tests/envs/_apps/ytt-installation/ytt/app.yaml
+++ b/examples/kcl-integration-tests/envs/_apps/ytt-installation/ytt/app.yaml
@@ -1,0 +1,8 @@
+#@ load("@ytt:data", "data")
+---
+kind: rendering
+metadata:
+  name: env-group
+outputYaml:
+  fromEnvGroup: true
+  fromEnvGroupAppData: #@ data.values.application.envGroupValue

--- a/examples/kcl-integration-tests/envs/_proto/helm-render-test/helm/render-test.baz.yaml
+++ b/examples/kcl-integration-tests/envs/_proto/helm-render-test/helm/render-test.baz.yaml
@@ -1,0 +1,3 @@
+---
+outputYaml:
+  extraValuesProtoOverrideBaz: true

--- a/examples/kcl-integration-tests/envs/_proto/helm-render-test/helm/render-test.yaml
+++ b/examples/kcl-integration-tests/envs/_proto/helm-render-test/helm/render-test.yaml
@@ -1,0 +1,5 @@
+#@ load("@ytt:data", "data")
+---
+outputYaml:
+  fromPrototypeOverride: true
+  fromPrototypeOverrideFromAppData: #@ data.values.application.protoOverwriteValue

--- a/examples/kcl-integration-tests/envs/_proto/ytt-render-test/ytt/proto.yaml
+++ b/examples/kcl-integration-tests/envs/_proto/ytt-render-test/ytt/proto.yaml
@@ -1,0 +1,8 @@
+#@ load("@ytt:data", "data")
+---
+kind: rendering
+metadata:
+  name: proto
+outputYaml:
+  fromPrototypeOverride: true
+  fromPrototypeOverrideFromAppData: #@ data.values.application.protoOverwriteValue

--- a/examples/kcl-integration-tests/envs/dev/_apps/helm-installation/helm/render-test.yaml
+++ b/examples/kcl-integration-tests/envs/dev/_apps/helm-installation/helm/render-test.yaml
@@ -1,0 +1,5 @@
+#@ load("@ytt:data", "data")
+---
+outputYaml:
+  fromAppConfig: true
+  fromAppConfigAppData: #@ data.values.application.appValue

--- a/examples/kcl-integration-tests/envs/dev/_apps/lib-test/lib/application.star
+++ b/examples/kcl-integration-tests/envs/dev/_apps/lib-test/lib/application.star
@@ -1,0 +1,1 @@
+applicationVar = "defined in application"

--- a/examples/kcl-integration-tests/envs/dev/_apps/multiple-sources/helm/_global.yaml
+++ b/examples/kcl-integration-tests/envs/dev/_apps/multiple-sources/helm/_global.yaml
@@ -1,0 +1,4 @@
+outputYaml:
+  fromAppGlobal: true
+  appSpecificChart: appGlobal
+  appGlobal: appGlobal

--- a/examples/kcl-integration-tests/envs/dev/_apps/multiple-sources/helm/render-test-1.yaml
+++ b/examples/kcl-integration-tests/envs/dev/_apps/multiple-sources/helm/render-test-1.yaml
@@ -1,0 +1,3 @@
+outputYaml:
+  fromAppSpecificChart: true
+  appSpecificChart: appSpecificChart

--- a/examples/kcl-integration-tests/envs/dev/_apps/ytt-installation/ytt/app.yaml
+++ b/examples/kcl-integration-tests/envs/dev/_apps/ytt-installation/ytt/app.yaml
@@ -1,0 +1,8 @@
+#@ load("@ytt:data", "data")
+---
+kind: rendering
+metadata:
+  name: app
+outputYaml:
+  fromAppConfig: true
+  fromAppConfigAppData: #@ data.values.application.appValue

--- a/examples/kcl-integration-tests/envs/dev/_proto/helm-render-test/helm/render-test.yaml
+++ b/examples/kcl-integration-tests/envs/dev/_proto/helm-render-test/helm/render-test.yaml
@@ -1,0 +1,5 @@
+#@ load("@ytt:data", "data")
+---
+outputYaml:
+  fromPrototypeOverride: true
+  fromPrototypeOverrideFromAppData: #@ data.values.application.protoOverwriteValue

--- a/examples/kcl-integration-tests/envs/dev/_proto/ytt-render-test/ytt/proto.yaml
+++ b/examples/kcl-integration-tests/envs/dev/_proto/ytt-render-test/ytt/proto.yaml
@@ -1,0 +1,8 @@
+#@ load("@ytt:data", "data")
+---
+kind: rendering
+metadata:
+  name: proto
+outputYaml:
+  fromPrototypeOverride: true
+  fromPrototypeOverrideFromAppData: #@ data.values.application.protoOverwriteValue

--- a/examples/kcl-integration-tests/envs/dev/env.k
+++ b/examples/kcl-integration-tests/envs/dev/env.k
@@ -1,0 +1,21 @@
+# Leaf environment: identity plus dev-level application overrides.
+# Note the `:` (merge) on dict attributes — `=` would replace the inherited dict wholesale.
+import myks as m
+
+import envs
+
+_id = "mykso-dev"
+
+env = m.finalize(envs.env | {
+    id = _id
+    applications: {
+        "argocd-tests": {
+            # envId is derived from the environment id — in the legacy fixture this was a
+            # ytt load of the environment data lib in the prototype's app-data file.
+            application: {envId = _id}
+            argocd: {app: {source: {plugin = None}}}
+        }
+        "helm-installation": {application: {appValue = True}}
+        "ytt-installation": {application: {envId = _id, appValue = True}}
+    }
+})

--- a/examples/kcl-integration-tests/envs/env.k
+++ b/examples/kcl-integration-tests/envs/env.k
@@ -1,0 +1,64 @@
+# Root level: shared defaults and the application roster with root-level values.
+# This is the KCL port of the legacy fixture's envs/env-data.ytt.yaml plus the
+# app-data.ytt.yaml files of prototypes/, envs/_proto/ and envs/_apps/.
+import myks as m
+
+env = m.Environment {
+    argocd = {
+        namespace = "system-argocd"
+        app = {
+            prefix = "app-"
+            # Kept for parity with the legacy fixture; ytt ignores an empty array in a
+            # data-values document, so the default finalizer stays in the rendered output.
+            finalizers = []
+            source = {
+                plugin = {name = "argocd-vault-plugin-v1.0.0"}
+                # Fixed config to run tests successfully in pipeline
+                targetRevision = "main"
+                repoURL = "git@github.com:mykso/myks.git"
+            }
+        }
+        project = {prefix = "env-"}
+    }
+    # Fixed git config to run tests successfully in pipeline.
+    myks = {
+        gitRepoBranch = "main"
+        gitRepoUrl = "git@github.com:mykso/myks.git"
+    }
+    applications = {
+        "argocd-tests" = m.App {
+            proto = "ytt-render-test"
+            application = {
+                baseValue = True
+                protoOverwriteValue = True
+            }
+        }
+        "helm-installation" = m.App {
+            proto = "helm-render-test"
+            application = {
+                baseValue = True
+                protoOverwriteValue = True
+                envGroupValue = True
+            }
+        }
+        "per-chart-override" = m.App {
+            helm.charts = [
+                {name = "render-test-1", releaseName = "overridden-release-name-1"}
+                {name = "render-test-2", releaseName = "overridden-release-name-2"}
+            ]
+        }
+        "multiple-sources" = m.App {}
+        "multiple-contents-sources" = m.App {}
+        "ytt-installation" = m.App {
+            proto = "ytt-render-test"
+            application = {
+                baseValue = True
+                protoOverwriteValue = True
+                envGroupValue = True
+            }
+        }
+        "static-test" = m.App {}
+        "helm-myks-context" = m.App {}
+        "lib-test" = m.App {}
+    }
+}

--- a/examples/kcl-integration-tests/kcl.mod
+++ b/examples/kcl-integration-tests/kcl.mod
@@ -7,3 +7,5 @@ version = "0.1.0"
 #   kcl mod add oci://ghcr.io/mykso/myks
 [dependencies]
 myks = { path = "../../kcl/myks" }
+
+# vim: ft=toml:

--- a/examples/kcl-integration-tests/kcl.mod
+++ b/examples/kcl-integration-tests/kcl.mod
@@ -1,0 +1,9 @@
+[package]
+name = "config"
+version = "0.1.0"
+
+# In-repo example: the myks schema package is consumed by path so the example
+# always tracks the engine at HEAD. User repos pin the published package instead:
+#   kcl mod add oci://ghcr.io/mykso/myks
+[dependencies]
+myks = { path = "../../kcl/myks" }

--- a/examples/kcl-integration-tests/kcl.mod.lock
+++ b/examples/kcl-integration-tests/kcl.mod.lock
@@ -1,0 +1,5 @@
+[dependencies]
+  [dependencies.myks]
+    name = "myks"
+    full_name = "myks_0.1.0"
+    version = "0.1.0"

--- a/examples/kcl-integration-tests/lib/global.star
+++ b/examples/kcl-integration-tests/lib/global.star
@@ -1,0 +1,1 @@
+globalVar = "defined in global"

--- a/examples/kcl-integration-tests/main.k
+++ b/examples/kcl-integration-tests/main.k
@@ -1,0 +1,10 @@
+# Root evaluation: emits the frozen resolved tree consumed by myks.
+# Environments are discovered from this output only — no filesystem walk.
+import myks
+
+import envs.dev
+
+myksSchemaVersion = myks.SCHEMA_VERSION
+environments = {
+    dev = dev.env
+}

--- a/examples/kcl-integration-tests/prototypes/helm-myks-context/helm/test-chart-name.yaml
+++ b/examples/kcl-integration-tests/prototypes/helm-myks-context/helm/test-chart-name.yaml
@@ -1,0 +1,4 @@
+#@ load("@ytt:data", "data")
+---
+outputYaml:
+  myksContext: #@ data.values.myks.context

--- a/examples/kcl-integration-tests/prototypes/helm-myks-context/vendir/base.ytt.yaml
+++ b/examples/kcl-integration-tests/prototypes/helm-myks-context/vendir/base.ytt.yaml
@@ -1,0 +1,12 @@
+#@ load("@ytt:data", "data")
+
+#@ app = data.values.application
+---
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: charts/test-chart-name
+    contents:
+      - path: .
+        directory:
+          path: ../_lib/charts/render-test-chart

--- a/examples/kcl-integration-tests/prototypes/helm-render-test/helm/render-test.bar.yaml
+++ b/examples/kcl-integration-tests/prototypes/helm-render-test/helm/render-test.bar.yaml
@@ -1,0 +1,3 @@
+---
+outputYaml:
+  extraValuesProtoBar: true

--- a/examples/kcl-integration-tests/prototypes/helm-render-test/helm/render-test.foo.yaml
+++ b/examples/kcl-integration-tests/prototypes/helm-render-test/helm/render-test.foo.yaml
@@ -1,0 +1,3 @@
+---
+outputYaml:
+  extraValuesProtoFoo: true

--- a/examples/kcl-integration-tests/prototypes/helm-render-test/helm/render-test.yaml
+++ b/examples/kcl-integration-tests/prototypes/helm-render-test/helm/render-test.yaml
@@ -1,0 +1,5 @@
+#@ load("@ytt:data", "data")
+---
+outputYaml:
+  fromPrototype: true
+  fromPrototypeAppData: #@ data.values.application.baseValue

--- a/examples/kcl-integration-tests/prototypes/helm-render-test/vendir/base.ytt.yaml
+++ b/examples/kcl-integration-tests/prototypes/helm-render-test/vendir/base.ytt.yaml
@@ -1,0 +1,12 @@
+#@ load("@ytt:data", "data")
+
+#@ app = data.values.application
+---
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: #@ "charts/" + app.name
+    contents:
+      - path: .
+        directory:
+          path: ../_lib/charts/render-test-chart

--- a/examples/kcl-integration-tests/prototypes/helm-render-test/vendir/data-tests.ytt.yaml
+++ b/examples/kcl-integration-tests/prototypes/helm-render-test/vendir/data-tests.ytt.yaml
@@ -1,0 +1,8 @@
+#! Test access to the wider data context
+
+#@ load("@ytt:assert", "assert")
+#@ load("@ytt:data", "data")
+
+#@ assert.equals(data.values.application.baseValue, True)
+#@ assert.equals(data.values.environment.id, "mykso-dev")
+#@ assert.equals(data.values.myks.gitRepoBranch, "main")

--- a/examples/kcl-integration-tests/prototypes/helm-render-test/vendir/vendir-data.ytt.yaml
+++ b/examples/kcl-integration-tests/prototypes/helm-render-test/vendir/vendir-data.ytt.yaml
@@ -1,0 +1,9 @@
+#@data/values-schema
+---
+#@overlay/match-child-defaults missing_ok=True
+application:
+  #! WARNING: The order of the keys (alphabetical) is important for renovate.
+  #!          When changed, renovate won't be able to detect the new version.
+  #!          See renovate.json for more details.
+  #! renovate: datasource=helm
+  name: render-test

--- a/examples/kcl-integration-tests/prototypes/lib-test/lib/prototype.star
+++ b/examples/kcl-integration-tests/prototypes/lib-test/lib/prototype.star
@@ -1,0 +1,1 @@
+prototypeVar = "defined in prototype"

--- a/examples/kcl-integration-tests/prototypes/lib-test/ytt/all.ytt.yaml
+++ b/examples/kcl-integration-tests/prototypes/lib-test/ytt/all.ytt.yaml
@@ -1,0 +1,11 @@
+#@ load("application.star", "applicationVar")
+#@ load("global.star", "globalVar")
+#@ load("prototype.star", "prototypeVar")
+
+---
+kind: MyksTest
+metadata:
+  name: lib-test
+applicationVar: #@ applicationVar
+globalVar: #@ globalVar
+prototypeVar: #@ prototypeVar

--- a/examples/kcl-integration-tests/prototypes/multiple-contents-sources/vendir/all.ytt.yaml
+++ b/examples/kcl-integration-tests/prototypes/multiple-contents-sources/vendir/all.ytt.yaml
@@ -1,0 +1,17 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: .
+    contents:
+      - path: charts/render-test-1
+        directory:
+          path: ../_lib/charts/render-test-chart
+      - path: charts/render-test-2
+        directory:
+          path: ../_lib/charts/render-test-chart
+      - path: ytt/render-test-1
+        directory:
+          path: ../_lib/ytt/render-test-1
+      - path: ytt/render-test-2
+        directory:
+          path: ../_lib/ytt/render-test-2

--- a/examples/kcl-integration-tests/prototypes/multiple-sources/helm/_global.yaml
+++ b/examples/kcl-integration-tests/prototypes/multiple-sources/helm/_global.yaml
@@ -1,0 +1,4 @@
+outputYaml:
+  fromPrototypeGlobal: true
+  appSpecificChart: prototypeGlobal
+  appGlobal: prototypeGlobal

--- a/examples/kcl-integration-tests/prototypes/multiple-sources/vendir/all.ytt.yaml
+++ b/examples/kcl-integration-tests/prototypes/multiple-sources/vendir/all.ytt.yaml
@@ -1,0 +1,23 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: charts/render-test-1
+    contents:
+      - path: .
+        directory:
+          path: ../_lib/charts/render-test-chart
+  - path: charts/render-test-2
+    contents:
+      - path: .
+        directory:
+          path: ../_lib/charts/render-test-chart
+  - path: ytt/render-test-1
+    contents:
+      - path: .
+        directory:
+          path: ../_lib/ytt/render-test-1
+  - path: ytt/render-test-2
+    contents:
+      - path: .
+        directory:
+          path: ../_lib/ytt/render-test-2

--- a/examples/kcl-integration-tests/prototypes/per-chart-override/vendir/all.ytt.yaml
+++ b/examples/kcl-integration-tests/prototypes/per-chart-override/vendir/all.ytt.yaml
@@ -1,0 +1,13 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: charts/render-test-1
+    contents:
+      - path: .
+        directory:
+          path: ../_lib/charts/render-test-chart
+  - path: charts/render-test-2
+    contents:
+      - path: .
+        directory:
+          path: ../_lib/charts/render-test-chart

--- a/examples/kcl-integration-tests/prototypes/static-test/static/literal.yaml
+++ b/examples/kcl-integration-tests/prototypes/static-test/static/literal.yaml
@@ -1,0 +1,9 @@
+---
+# https://kubernetes.io/docs/concepts/configuration/configmap/
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: static-test-cm
+  namespace: default
+data:
+  key: value

--- a/examples/kcl-integration-tests/prototypes/ytt-render-test/ytt/base.yaml
+++ b/examples/kcl-integration-tests/prototypes/ytt-render-test/ytt/base.yaml
@@ -1,0 +1,9 @@
+#@ load("@ytt:data", "data")
+---
+kind: rendering
+metadata:
+  name: base
+outputYaml:
+  fromPrototype: true
+  fromPrototypeAppData: #@ data.values.application.baseValue
+appData: #@ data.values.application

--- a/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-argocd-tests.yaml
+++ b/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-argocd-tests.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: app-mykso-dev-argocd-tests
+  namespace: system-argocd
+spec:
+  destination:
+    name: mykso-dev
+    namespace: argocd-tests
+  project: env-mykso-dev
+  source:
+    path: examples/kcl-integration-tests/rendered/envs/mykso-dev/argocd-tests
+    repoURL: git@github.com:mykso/myks.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-helm-installation.yaml
+++ b/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-helm-installation.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: app-mykso-dev-helm-installation
+  namespace: system-argocd
+spec:
+  destination:
+    name: mykso-dev
+    namespace: helm-installation
+  project: env-mykso-dev
+  source:
+    path: examples/kcl-integration-tests/rendered/envs/mykso-dev/helm-installation
+    plugin:
+      name: argocd-vault-plugin-v1.0.0
+    repoURL: git@github.com:mykso/myks.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-helm-myks-context.yaml
+++ b/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-helm-myks-context.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: app-mykso-dev-helm-myks-context
+  namespace: system-argocd
+spec:
+  destination:
+    name: mykso-dev
+    namespace: helm-myks-context
+  project: env-mykso-dev
+  source:
+    path: examples/kcl-integration-tests/rendered/envs/mykso-dev/helm-myks-context
+    plugin:
+      name: argocd-vault-plugin-v1.0.0
+    repoURL: git@github.com:mykso/myks.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-lib-test.yaml
+++ b/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-lib-test.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: app-mykso-dev-lib-test
+  namespace: system-argocd
+spec:
+  destination:
+    name: mykso-dev
+    namespace: lib-test
+  project: env-mykso-dev
+  source:
+    path: examples/kcl-integration-tests/rendered/envs/mykso-dev/lib-test
+    plugin:
+      name: argocd-vault-plugin-v1.0.0
+    repoURL: git@github.com:mykso/myks.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-multiple-contents-sources.yaml
+++ b/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-multiple-contents-sources.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: app-mykso-dev-multiple-contents-sources
+  namespace: system-argocd
+spec:
+  destination:
+    name: mykso-dev
+    namespace: multiple-contents-sources
+  project: env-mykso-dev
+  source:
+    path: examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-contents-sources
+    plugin:
+      name: argocd-vault-plugin-v1.0.0
+    repoURL: git@github.com:mykso/myks.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-multiple-sources.yaml
+++ b/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-multiple-sources.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: app-mykso-dev-multiple-sources
+  namespace: system-argocd
+spec:
+  destination:
+    name: mykso-dev
+    namespace: multiple-sources
+  project: env-mykso-dev
+  source:
+    path: examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-sources
+    plugin:
+      name: argocd-vault-plugin-v1.0.0
+    repoURL: git@github.com:mykso/myks.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-per-chart-override.yaml
+++ b/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-per-chart-override.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: app-mykso-dev-per-chart-override
+  namespace: system-argocd
+spec:
+  destination:
+    name: mykso-dev
+    namespace: per-chart-override
+  project: env-mykso-dev
+  source:
+    path: examples/kcl-integration-tests/rendered/envs/mykso-dev/per-chart-override
+    plugin:
+      name: argocd-vault-plugin-v1.0.0
+    repoURL: git@github.com:mykso/myks.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-static-test.yaml
+++ b/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-static-test.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: app-mykso-dev-static-test
+  namespace: system-argocd
+spec:
+  destination:
+    name: mykso-dev
+    namespace: static-test
+  project: env-mykso-dev
+  source:
+    path: examples/kcl-integration-tests/rendered/envs/mykso-dev/static-test
+    plugin:
+      name: argocd-vault-plugin-v1.0.0
+    repoURL: git@github.com:mykso/myks.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-ytt-installation.yaml
+++ b/examples/kcl-integration-tests/rendered/argocd/mykso-dev/app-ytt-installation.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  name: app-mykso-dev-ytt-installation
+  namespace: system-argocd
+spec:
+  destination:
+    name: mykso-dev
+    namespace: ytt-installation
+  project: env-mykso-dev
+  source:
+    path: examples/kcl-integration-tests/rendered/envs/mykso-dev/ytt-installation
+    plugin:
+      name: argocd-vault-plugin-v1.0.0
+    repoURL: git@github.com:mykso/myks.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/examples/kcl-integration-tests/rendered/argocd/mykso-dev/env-mykso-dev.yaml
+++ b/examples/kcl-integration-tests/rendered/argocd/mykso-dev/env-mykso-dev.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: env-mykso-dev
+  namespace: system-argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  description: Project for "mykso-dev" environment
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  destinations:
+  - namespace: '*'
+    name: mykso-dev
+  namespaceResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  sourceRepos:
+  - '*'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+  name: mykso-dev
+  namespace: system-argocd
+stringData:
+  config: ARGOCD_CLUSTER_CONNECT_CONFIG
+  name: mykso-dev
+  project: env-mykso-dev
+  server: ARGOCD_CLUSTER_SERVER_URL

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/argocd-tests/rendering-base.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/argocd-tests/rendering-base.yaml
@@ -1,0 +1,10 @@
+appData:
+  baseValue: true
+  envId: mykso-dev
+  protoOverwriteValue: true
+kind: rendering
+metadata:
+  name: base
+outputYaml:
+  fromPrototype: true
+  fromPrototypeAppData: true

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/argocd-tests/rendering-proto.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/argocd-tests/rendering-proto.yaml
@@ -1,0 +1,6 @@
+kind: rendering
+metadata:
+  name: proto
+outputYaml:
+  fromPrototypeOverride: true
+  fromPrototypeOverrideFromAppData: true

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/helm-installation/rendering-helm-render-test.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/helm-installation/rendering-helm-render-test.yaml
@@ -1,0 +1,17 @@
+kind: rendering
+metadata:
+  name: helm-render-test
+outputYaml:
+  extraValuesAppQuux: true
+  extraValuesProtoBar: true
+  extraValuesProtoFoo: true
+  extraValuesProtoOverrideBaz: true
+  fromAppConfig: true
+  fromAppConfigAppData: true
+  fromChartDefaultValues: true
+  fromEnvGroup: true
+  fromEnvGroupAppData: true
+  fromPrototype: true
+  fromPrototypeAppData: true
+  fromPrototypeOverride: true
+  fromPrototypeOverrideFromAppData: true

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/helm-myks-context/rendering-helm-test-chart-name.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/helm-myks-context/rendering-helm-test-chart-name.yaml
@@ -1,0 +1,11 @@
+kind: rendering
+metadata:
+  name: helm-test-chart-name
+outputYaml:
+  fromChartDefaultValues: true
+  myksContext:
+    app: helm-myks-context
+    helm:
+      chart: test-chart-name
+    prototype: prototypes/helm-myks-context
+    step: render

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/lib-test/mykstest-lib-test.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/lib-test/mykstest-lib-test.yaml
@@ -1,0 +1,6 @@
+applicationVar: defined in application
+globalVar: defined in global
+kind: MyksTest
+metadata:
+  name: lib-test
+prototypeVar: defined in prototype

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-contents-sources/rendering-helm-render-test-1.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-contents-sources/rendering-helm-render-test-1.yaml
@@ -1,0 +1,5 @@
+kind: rendering
+metadata:
+  name: helm-render-test-1
+outputYaml:
+  fromChartDefaultValues: true

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-contents-sources/rendering-helm-render-test-2.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-contents-sources/rendering-helm-render-test-2.yaml
@@ -1,0 +1,5 @@
+kind: rendering
+metadata:
+  name: helm-render-test-2
+outputYaml:
+  fromChartDefaultValues: true

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-contents-sources/rendering-ytt-render-test-1.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-contents-sources/rendering-ytt-render-test-1.yaml
@@ -1,0 +1,3 @@
+kind: rendering
+metadata:
+  name: ytt-render-test-1

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-contents-sources/rendering-ytt-render-test-2.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-contents-sources/rendering-ytt-render-test-2.yaml
@@ -1,0 +1,3 @@
+kind: rendering
+metadata:
+  name: ytt-render-test-2

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-sources/rendering-helm-render-test-1.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-sources/rendering-helm-render-test-1.yaml
@@ -1,0 +1,10 @@
+kind: rendering
+metadata:
+  name: helm-render-test-1
+outputYaml:
+  appGlobal: appGlobal
+  appSpecificChart: appSpecificChart
+  fromAppGlobal: true
+  fromAppSpecificChart: true
+  fromChartDefaultValues: true
+  fromPrototypeGlobal: true

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-sources/rendering-helm-render-test-2.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-sources/rendering-helm-render-test-2.yaml
@@ -1,0 +1,9 @@
+kind: rendering
+metadata:
+  name: helm-render-test-2
+outputYaml:
+  appGlobal: appGlobal
+  appSpecificChart: appGlobal
+  fromAppGlobal: true
+  fromChartDefaultValues: true
+  fromPrototypeGlobal: true

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-sources/rendering-ytt-render-test-1.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-sources/rendering-ytt-render-test-1.yaml
@@ -1,0 +1,3 @@
+kind: rendering
+metadata:
+  name: ytt-render-test-1

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-sources/rendering-ytt-render-test-2.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/multiple-sources/rendering-ytt-render-test-2.yaml
@@ -1,0 +1,3 @@
+kind: rendering
+metadata:
+  name: ytt-render-test-2

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/per-chart-override/rendering-helm-overridden-release-name-1.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/per-chart-override/rendering-helm-overridden-release-name-1.yaml
@@ -1,0 +1,5 @@
+kind: rendering
+metadata:
+  name: helm-overridden-release-name-1
+outputYaml:
+  fromChartDefaultValues: true

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/per-chart-override/rendering-helm-overridden-release-name-2.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/per-chart-override/rendering-helm-overridden-release-name-2.yaml
@@ -1,0 +1,5 @@
+kind: rendering
+metadata:
+  name: helm-overridden-release-name-2
+outputYaml:
+  fromChartDefaultValues: true

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/static-test/static/literal.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/static-test/static/literal.yaml
@@ -1,0 +1,9 @@
+---
+# https://kubernetes.io/docs/concepts/configuration/configmap/
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: static-test-cm
+  namespace: default
+data:
+  key: value

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/ytt-installation/rendering-app.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/ytt-installation/rendering-app.yaml
@@ -1,0 +1,6 @@
+kind: rendering
+metadata:
+  name: app
+outputYaml:
+  fromAppConfig: true
+  fromAppConfigAppData: true

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/ytt-installation/rendering-base.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/ytt-installation/rendering-base.yaml
@@ -1,0 +1,12 @@
+appData:
+  appValue: true
+  baseValue: true
+  envGroupValue: true
+  envId: mykso-dev
+  protoOverwriteValue: true
+kind: rendering
+metadata:
+  name: base
+outputYaml:
+  fromPrototype: true
+  fromPrototypeAppData: true

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/ytt-installation/rendering-env-group.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/ytt-installation/rendering-env-group.yaml
@@ -1,0 +1,6 @@
+kind: rendering
+metadata:
+  name: env-group
+outputYaml:
+  fromEnvGroup: true
+  fromEnvGroupAppData: true

--- a/examples/kcl-integration-tests/rendered/envs/mykso-dev/ytt-installation/rendering-proto.yaml
+++ b/examples/kcl-integration-tests/rendered/envs/mykso-dev/ytt-installation/rendering-proto.yaml
@@ -1,0 +1,6 @@
+kind: rendering
+metadata:
+  name: proto
+outputYaml:
+  fromPrototypeOverride: true
+  fromPrototypeOverrideFromAppData: true

--- a/internal/integration/kcl_gate_test.go
+++ b/internal/integration/kcl_gate_test.go
@@ -1,0 +1,135 @@
+package integration_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mykso/myks/cmd"
+	"github.com/mykso/myks/internal/myks"
+)
+
+// TestKclGate is the byte-identical migration gate (config-layer redesign, roadmap step 3):
+// the same logical repo rendered in legacy mode and in KCL mode must produce identical
+// rendered/ trees. It doubles as the test suite of the future `myks migrate` converter.
+func TestKclGate(t *testing.T) {
+	baseFolder, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer chgDir(t, baseFolder, "")
+
+	legacyRoot := "../../examples/integration-tests"
+	kclRoot := "../../examples/kcl-integration-tests"
+
+	renderRepo(t, baseFolder, legacyRoot)
+	renderRepo(t, baseFolder, kclRoot)
+
+	diffRenderedTrees(t, legacyRoot, kclRoot,
+		// Per-app waivers: app name -> reason. Waived apps are expected to differ because a
+		// KCL derivation intentionally changes values; their outputs are excluded from the diff.
+		map[string]string{},
+		// The repos live in different directories, so repo-relative paths baked into the output
+		// (e.g. the ArgoCD Application source.path) legitimately differ; normalize them away.
+		func(content []byte) []byte {
+			return bytes.ReplaceAll(content,
+				[]byte("examples/kcl-integration-tests/"),
+				[]byte("examples/integration-tests/"))
+		},
+	)
+}
+
+func renderRepo(t *testing.T, baseFolder, root string) {
+	t.Helper()
+	chgDir(t, baseFolder, root)
+	if err := cmd.RenderCmd(myks.New("."), true, true); err != nil {
+		t.Fatalf("Render of %s failed: %s", root, err)
+	}
+	chgDir(t, baseFolder, "")
+}
+
+// diffRenderedTrees compares the rendered/ trees of two repo roots byte for byte.
+// Waived applications are excluded from the comparison; normalize (optional) is applied to
+// every file of the second tree before comparing.
+func diffRenderedTrees(t *testing.T, wantRoot, gotRoot string, waivedApps map[string]string, normalize func([]byte) []byte) {
+	t.Helper()
+
+	for app, reason := range waivedApps {
+		t.Logf("Waived app %q: %s", app, reason)
+	}
+
+	wantFiles := collectRenderedFiles(t, wantRoot, waivedApps)
+	gotFiles := collectRenderedFiles(t, gotRoot, waivedApps)
+
+	for path, want := range wantFiles {
+		got, ok := gotFiles[path]
+		if !ok {
+			t.Errorf("missing rendered file: %s", path)
+			continue
+		}
+		if normalize != nil {
+			got = normalize(got)
+		}
+		if !bytes.Equal(want, got) {
+			t.Errorf("rendered file differs: %s\n--- %s\n%s\n--- %s\n%s", path, wantRoot, want, gotRoot, got)
+		}
+	}
+	for path := range gotFiles {
+		if _, ok := wantFiles[path]; !ok {
+			t.Errorf("unexpected rendered file: %s", path)
+		}
+	}
+}
+
+// collectRenderedFiles maps rendered/-relative file paths to their content, skipping waived apps.
+// Waived paths are rendered/envs/<env>/<app>/** and rendered/argocd/<env>/app-<app>.yaml.
+func collectRenderedFiles(t *testing.T, root string, waivedApps map[string]string) map[string][]byte {
+	t.Helper()
+	files := map[string][]byte{}
+	renderedDir := filepath.Join(root, "rendered")
+	err := filepath.WalkDir(renderedDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(renderedDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if isWaivedPath(rel, waivedApps) {
+			return nil
+		}
+		content, err := os.ReadFile(path) // #nosec G304 -- paths come from walking the test fixture
+		if err != nil {
+			return err
+		}
+		files[rel] = content
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %s", renderedDir, err)
+	}
+	return files
+}
+
+func isWaivedPath(relPath string, waivedApps map[string]string) bool {
+	parts := strings.Split(relPath, "/")
+	if len(parts) < 3 {
+		return false
+	}
+	for app := range waivedApps {
+		switch parts[0] {
+		case "envs":
+			if parts[2] == app {
+				return true
+			}
+		case "argocd":
+			if parts[2] == "app-"+app+".yaml" {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/integration/kcl_gate_test.go
+++ b/internal/integration/kcl_gate_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mykso/myks/cmd"
 	"github.com/mykso/myks/internal/myks"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // TestKclGate is the byte-identical migration gate (config-layer redesign, roadmap step 3):
@@ -31,13 +32,8 @@ func TestKclGate(t *testing.T) {
 		// Per-app waivers: app name -> reason. Waived apps are expected to differ because a
 		// KCL derivation intentionally changes values; their outputs are excluded from the diff.
 		map[string]string{},
-		// The repos live in different directories, so repo-relative paths baked into the output
-		// (e.g. the ArgoCD Application source.path) legitimately differ; normalize them away.
-		func(content []byte) []byte {
-			return bytes.ReplaceAll(content,
-				[]byte("examples/kcl-integration-tests/"),
-				[]byte("examples/integration-tests/"))
-		},
+		// The repos live in different directories, so ArgoCD Application source paths legitimately differ.
+		normalizeArgoCDSourcePath,
 	)
 }
 
@@ -52,8 +48,8 @@ func renderRepo(t *testing.T, baseFolder, root string) {
 
 // diffRenderedTrees compares the rendered/ trees of two repo roots byte for byte.
 // Waived applications are excluded from the comparison; normalize (optional) is applied to
-// every file of the second tree before comparing.
-func diffRenderedTrees(t *testing.T, wantRoot, gotRoot string, waivedApps map[string]string, normalize func([]byte) []byte) {
+// files of the second tree before comparing.
+func diffRenderedTrees(t *testing.T, wantRoot, gotRoot string, waivedApps map[string]string, normalize func(*testing.T, string, []byte) []byte) {
 	t.Helper()
 
 	for app, reason := range waivedApps {
@@ -70,7 +66,7 @@ func diffRenderedTrees(t *testing.T, wantRoot, gotRoot string, waivedApps map[st
 			continue
 		}
 		if normalize != nil {
-			got = normalize(got)
+			got = normalize(t, path, got)
 		}
 		if !bytes.Equal(want, got) {
 			t.Errorf("rendered file differs: %s\n--- %s\n%s\n--- %s\n%s", path, wantRoot, want, gotRoot, got)
@@ -80,6 +76,64 @@ func diffRenderedTrees(t *testing.T, wantRoot, gotRoot string, waivedApps map[st
 		if _, ok := wantFiles[path]; !ok {
 			t.Errorf("unexpected rendered file: %s", path)
 		}
+	}
+}
+
+// normalizeArgoCDSourcePath reconciles the fixture-root difference only in an ArgoCD
+// Application's spec.source.path. Every other rendered value remains byte-compared.
+func normalizeArgoCDSourcePath(t *testing.T, relPath string, content []byte) []byte {
+	t.Helper()
+	if !strings.HasPrefix(relPath, "argocd/") || !strings.HasPrefix(filepath.Base(relPath), "app-") {
+		return content
+	}
+
+	var application struct {
+		Kind string `yaml:"kind"`
+		Spec struct {
+			Source struct {
+				Path string `yaml:"path"`
+			} `yaml:"source"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(content, &application); err != nil {
+		t.Fatalf("parsing ArgoCD Application %s: %s", relPath, err)
+	}
+	if application.Kind != "Application" || !strings.HasPrefix(application.Spec.Source.Path, "examples/kcl-integration-tests/") {
+		return content
+	}
+
+	got := []byte("path: " + application.Spec.Source.Path)
+	if bytes.Count(content, got) != 1 {
+		t.Fatalf("finding unique spec.source.path in %s", relPath)
+	}
+	want := []byte("path: " + strings.Replace(application.Spec.Source.Path, "examples/kcl-integration-tests/", "examples/integration-tests/", 1))
+	return bytes.Replace(content, got, want, 1)
+}
+
+func TestNormalizeArgoCDSourcePath(t *testing.T) {
+	t.Parallel()
+	content := []byte(`apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    repository: examples/kcl-integration-tests/
+spec:
+  source:
+    path: examples/kcl-integration-tests/rendered/envs/dev/app
+`)
+
+	got := normalizeArgoCDSourcePath(t, "argocd/dev/app-app.yaml", content)
+	want := []byte(`apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    repository: examples/kcl-integration-tests/
+spec:
+  source:
+    path: examples/integration-tests/rendered/envs/dev/app
+`)
+	if !bytes.Equal(got, want) {
+		t.Errorf("normalized content differs:\nwant:\n%s\ngot:\n%s", want, got)
 	}
 }
 

--- a/internal/myks/application.go
+++ b/internal/myks/application.go
@@ -136,12 +136,17 @@ func (a *Application) collectDataFiles() {
 	APILibraries := []string{a.e.getYttLibAPIDir()}
 	appLibraries := a.collectAllFilesByGlob(a.cfg.YttLibraryDirName)
 	if a.e.kclMode {
-		// KCL mode: the resolved config comes frozen from the KCL tree as a generated
-		// data-values bridge file; only data-values files are skipped — ytt lib dirs still apply.
+		// KCL mode: the resolved config comes frozen from the KCL tree as generated bridge
+		// files (env-level, then app-level, so app values win — mirroring the legacy order);
+		// only data-values files are skipped — ytt lib dirs still apply.
 		a.yttDataFiles = slices.Concat(
 			APILibraries,
 			appLibraries,
-			[]string{a.expandServicePath(kclGeneratedAppDataFileName)},
+			a.e.kclDataFiles,
+			[]string{
+				a.expandServicePath(kclAppSchemaFileName),
+				a.expandServicePath(kclAppValuesFileName),
+			},
 		)
 		return
 	}

--- a/internal/myks/environment.go
+++ b/internal/myks/environment.go
@@ -50,6 +50,8 @@ type Environment struct {
 	initialized   bool
 	// Environment is defined by the KCL frozen tree, not by env-data files
 	kclMode bool
+	// Generated env-level ytt data files (schema + values), used instead of env-data files in KCL mode
+	kclDataFiles []string
 	// Runtime data
 	renderedDataLibFilePath string
 	// Found applications
@@ -185,7 +187,7 @@ func (e *Environment) setID() error {
 }
 
 func (e *Environment) initEnvData() error {
-	envDataFiles := e.collectBySubpath(e.cfg.EnvironmentDataFileName)
+	envDataFiles := e.envDataFiles()
 	envDataYaml, err := e.renderEnvData(envDataFiles)
 	if err != nil {
 		log.Warn().Err(err).Str("dir", e.Dir).Msg(e.Msg("Unable to render environment data"))
@@ -206,6 +208,15 @@ func (e *Environment) initEnvData() error {
 	}
 
 	return nil
+}
+
+// envDataFiles returns the environment's data-values source files:
+// the generated bridge files in KCL mode, the env-data files of the dir hierarchy otherwise.
+func (e *Environment) envDataFiles() []string {
+	if e.kclMode {
+		return e.kclDataFiles
+	}
+	return e.collectBySubpath(e.cfg.EnvironmentDataFileName)
 }
 
 func (e *Environment) renderEnvData(envDataFiles []string) ([]byte, error) {

--- a/internal/myks/kcl.go
+++ b/internal/myks/kcl.go
@@ -16,19 +16,33 @@ import (
 const (
 	// kclModFileName is the KCL module manifest; its presence at the config root selects KCL mode.
 	kclModFileName = "kcl.mod"
-	// kclGeneratedAppDataFileName is the per-app data-values bridge file generated from the frozen tree.
-	// It is the only ytt data file of a KCL-mode application.
-	kclGeneratedAppDataFileName = "app-data.kcl-generated.ytt.yaml"
+	// Generated ytt bridge files (per environment and per application). Each config unit is
+	// split in two because ytt forbids mixing schema and plain data-values documents in one file:
+	// the schema part extends the embedded data schema with keys unknown to it, the values part
+	// sets values of the engine-owned scopes (plain data values, unlike schema docs, can carry
+	// array values).
+	kclEnvSchemaFileName = "env-data.kcl-schema.ytt.yaml"
+	kclEnvValuesFileName = "env-data.kcl-values.ytt.yaml"
+	kclAppSchemaFileName = "app-data.kcl-schema.ytt.yaml"
+	kclAppValuesFileName = "app-data.kcl-values.ytt.yaml"
 )
+
+// kclEmbeddedScopes are the engine-owned top-level data-values scopes with a fixed schema
+// (assets/data-schema.ytt.yaml). Their resolved values go into the generated plain data-values
+// file; all other keys extend the schema, exactly like legacy app-data schema documents do.
+var kclEmbeddedScopes = map[string]bool{
+	"argocd":      true,
+	"environment": true,
+	"helm":        true,
+	"kbld":        true,
+	"myks":        true,
+	"render":      true,
+	"yttPkg":      true,
+}
 
 // supportedKclSchemaVersion is the myks schema version the engine understands.
 // Kept in lockstep with kcl/myks/version.k; compatibility is same major.minor.
 const supportedKclSchemaVersion = "0.1.0"
-
-// kclGeneratedAppDataHeader turns the resolved app config into a ytt schema-extension document.
-// A schema doc (not a plain data-values doc) is used so that keys unknown to the embedded
-// data schema (e.g. prototype-specific `application` values) are accepted.
-const kclGeneratedAppDataHeader = "#@data/values-schema\n#@overlay/match-child-defaults missing_ok=True\n---\n"
 
 // kclTree is the frozen resolved tree produced by evaluating the KCL config root.
 // It is the sole discovery mechanism for environments and applications in KCL mode.
@@ -47,6 +61,9 @@ type kclEnvironmentData struct {
 	ArgoCD map[string]any `yaml:"argocd"`
 	// Applications maps application names to their self-contained resolved config.
 	Applications map[string]map[string]any `yaml:"applications"`
+	// Extra captures the remaining env-level keys (e.g. the myks scope or a global value bag);
+	// they flow into the environment data values like legacy env-data content does.
+	Extra map[string]any `yaml:",inline"`
 }
 
 // isKclMode reports whether the repo opts into the KCL config layer (kcl.mod at the config root).
@@ -213,11 +230,15 @@ func matchEnvFilter(dir string, filter EnvAppMap) (appNames []string, matched bo
 }
 
 // initKclEnvironment builds a fully initialized Environment from one frozen-tree entry.
+// The tree entry is materialized as generated ytt bridge files (one env-level pair and one pair
+// per application), after which the regular environment initialization runs on top of them, so
+// legacy semantics (embedded schema defaults, env data lib, ArgoCD settings) apply unchanged.
 func (g *Globe) initKclEnvironment(dir string, envData kclEnvironmentData, appNames []string) (*Environment, error) {
 	if envData.ID == "" {
 		return nil, fmt.Errorf("environment entry is missing id")
 	}
 
+	serviceDir := filepath.Join(g.RootDir, g.ServiceDirName, dir)
 	env := &Environment{
 		Dir:                     dir,
 		ID:                      envData.ID,
@@ -225,95 +246,87 @@ func (g *Globe) initKclEnvironment(dir string, envData kclEnvironmentData, appNa
 		g:                       g,
 		cfg:                     &g.Config,
 		extraYttPaths:           g.extraYttPaths,
-		renderedDataLibFilePath: filepath.Join(g.RootDir, g.ServiceDirName, dir, g.RenderedEnvironmentDataLibFileName),
+		renderedDataLibFilePath: filepath.Join(serviceDir, g.RenderedEnvironmentDataLibFileName),
 		foundApplications:       map[string]string{},
 		kclMode:                 true,
+		kclDataFiles: []string{
+			filepath.Join(serviceDir, kclEnvSchemaFileName),
+			filepath.Join(serviceDir, kclEnvValuesFileName),
+		},
 	}
 
-	// ArgoCD is opt-in per tree entry in KCL mode (unlike the legacy schema default of true).
-	if v, present := envData.ArgoCD["enabled"]; present {
-		enabled, ok := v.(bool)
-		if !ok {
-			return nil, fmt.Errorf("argocd.enabled must be a boolean, got %T (%v)", v, v)
-		}
-		env.argoCDEnabled = enabled
-	}
-
-	envDataYaml, err := envData.dataValuesYaml()
-	if err != nil {
-		return nil, err
-	}
-	envDataLib, err := env.renderEnvDataLib(envDataYaml)
-	if err != nil {
-		return nil, fmt.Errorf("rendering environment data lib: %w", err)
-	}
-	if err := env.saveRenderedEnvDataLib(envDataLib); err != nil {
-		return nil, fmt.Errorf("saving rendered environment data lib: %w", err)
+	if err := writeKclDataFiles(env.kclDataFiles[0], env.kclDataFiles[1], envData.dataValues()); err != nil {
+		return nil, fmt.Errorf("writing generated environment data values: %w", err)
 	}
 
 	for _, name := range slices.Sorted(maps.Keys(envData.Applications)) {
-		appConfig := envData.Applications[name]
-		proto := name
-		if p, ok := appConfig["proto"].(string); ok && p != "" {
-			proto = p
-		}
-		env.foundApplications[name] = proto
-
-		bridgeFile := filepath.Join(g.RootDir, g.ServiceDirName, dir, g.AppsDir, name, kclGeneratedAppDataFileName)
-		if err := writeKclAppDataFile(bridgeFile, appConfig); err != nil {
+		values := maps.Clone(envData.Applications[name])
+		delete(values, "proto")
+		appDir := filepath.Join(serviceDir, g.AppsDir, name)
+		err := writeKclDataFiles(
+			filepath.Join(appDir, kclAppSchemaFileName),
+			filepath.Join(appDir, kclAppValuesFileName),
+			values,
+		)
+		if err != nil {
 			return nil, fmt.Errorf("writing generated data values for app %s: %w", name, err)
 		}
 	}
 
-	if err := env.initApplications(appNames); err != nil {
-		return nil, fmt.Errorf("initializing applications: %w", err)
+	if err := env.Init(appNames); err != nil {
+		return nil, err
 	}
-	env.initialized = true
 
 	return env, nil
 }
 
-// dataValuesYaml serializes the environment entry as ytt data values
-// (feeds the env data lib consumed by templates via the myks ytt API).
-func (d kclEnvironmentData) dataValuesYaml() ([]byte, error) {
-	type appEntry struct {
-		// Name of the application.
-		Name string `yaml:"name"`
-		// Proto is the application's prototype name.
-		Proto string `yaml:"proto"`
+// dataValues shapes the environment entry as ytt data values: extras stay top-level scopes,
+// id and the application roster go under the engine-owned environment scope.
+func (d kclEnvironmentData) dataValues() map[string]any {
+	values := map[string]any{}
+	maps.Copy(values, d.Extra)
+	if d.ArgoCD != nil {
+		values["argocd"] = d.ArgoCD
 	}
-	data := struct {
-		ArgoCD      map[string]any `yaml:"argocd,omitempty"`
-		Environment struct {
-			ID           string     `yaml:"id"`
-			Applications []appEntry `yaml:"applications"`
-		} `yaml:"environment"`
-	}{ArgoCD: d.ArgoCD}
-	data.Environment.ID = d.ID
+
+	apps := make([]map[string]any, 0, len(d.Applications))
 	for _, name := range slices.Sorted(maps.Keys(d.Applications)) {
 		proto, _ := d.Applications[name]["proto"].(string)
 		if proto == "" {
 			proto = name
 		}
-		data.Environment.Applications = append(data.Environment.Applications, appEntry{Name: name, Proto: proto})
+		apps = append(apps, map[string]any{"name": name, "proto": proto})
 	}
+	values["environment"] = map[string]any{"id": d.ID, "applications": apps}
 
-	yamlBytes, err := yaml.Marshal(data)
-	if err != nil {
-		return nil, fmt.Errorf("marshalling environment data: %w", err)
-	}
-	return yamlBytes, nil
+	return values
 }
 
-// writeKclAppDataFile writes the app's resolved config (minus the engine-only proto key)
-// as a generated ytt data-values bridge file.
-func writeKclAppDataFile(path string, appConfig map[string]any) error {
-	values := maps.Clone(appConfig)
-	delete(values, "proto")
-
-	yamlBytes, err := yaml.Marshal(values)
-	if err != nil {
-		return fmt.Errorf("marshalling app data values: %w", err)
+// writeKclDataFiles writes one resolved config unit as a pair of generated ytt files:
+// keys unknown to the embedded data schema become a schema-extension document, engine-owned
+// scopes become a plain data-values document. Both files are always written (with an empty
+// body when there is nothing to say) so no stale content survives a re-run.
+func writeKclDataFiles(schemaPath, valuesPath string, values map[string]any) error {
+	schemaValues := map[string]any{}
+	plainValues := map[string]any{}
+	for key, value := range values {
+		if kclEmbeddedScopes[key] {
+			plainValues[key] = value
+		} else {
+			schemaValues[key] = value
+		}
 	}
-	return writeFile(path, append([]byte(kclGeneratedAppDataHeader), yamlBytes...))
+
+	write := func(path, header string, values map[string]any) error {
+		yamlBytes, err := yaml.Marshal(values)
+		if err != nil {
+			return fmt.Errorf("marshalling generated data values: %w", err)
+		}
+		return writeFile(path, append([]byte(header), yamlBytes...))
+	}
+
+	if err := write(schemaPath, "#@data/values-schema\n#@overlay/match-child-defaults missing_ok=True\n---\n", schemaValues); err != nil {
+		return err
+	}
+	return write(valuesPath, "#@data/values\n---\n", plainValues)
 }

--- a/internal/myks/kcl_test.go
+++ b/internal/myks/kcl_test.go
@@ -43,8 +43,8 @@ func TestMatchEnvFilter(t *testing.T) {
 	}
 }
 
-// TestKclEnvironmentDataValuesYaml verifies serialization of a tree entry into env data values.
-func TestKclEnvironmentDataValuesYaml(t *testing.T) {
+// TestKclEnvironmentDataValues verifies shaping of a tree entry into env data values.
+func TestKclEnvironmentDataValues(t *testing.T) {
 	t.Parallel()
 	envData := kclEnvironmentData{
 		ID:     "kcl-dev",
@@ -53,50 +53,58 @@ func TestKclEnvironmentDataValuesYaml(t *testing.T) {
 			"hello": {"proto": "hello-proto"},
 			"world": {},
 		},
+		Extra: map[string]any{"myks": map[string]any{"gitRepoBranch": "main"}},
 	}
-	yamlBytes, err := envData.dataValuesYaml()
-	require.NoError(t, err)
+	values := envData.dataValues()
 
-	var parsed struct {
-		ArgoCD      map[string]any `yaml:"argocd"`
-		Environment struct {
-			ID           string `yaml:"id"`
-			Applications []struct {
-				Name  string `yaml:"name"`
-				Proto string `yaml:"proto"`
-			} `yaml:"applications"`
-		} `yaml:"environment"`
-	}
-	require.NoError(t, yaml.Unmarshal(yamlBytes, &parsed))
-	assert.Equal(t, "kcl-dev", parsed.Environment.ID)
-	assert.Equal(t, map[string]any{"enabled": false}, parsed.ArgoCD)
-	require.Len(t, parsed.Environment.Applications, 2)
-	assert.Equal(t, "hello", parsed.Environment.Applications[0].Name)
-	assert.Equal(t, "hello-proto", parsed.Environment.Applications[0].Proto)
+	assert.Equal(t, map[string]any{"enabled": false}, values["argocd"])
+	assert.Equal(t, map[string]any{"gitRepoBranch": "main"}, values["myks"], "extra keys stay top-level scopes")
+
+	environment, ok := values["environment"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "kcl-dev", environment["id"])
+	apps, ok := environment["applications"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, apps, 2)
+	assert.Equal(t, map[string]any{"name": "hello", "proto": "hello-proto"}, apps[0])
 	// proto falls back to the application name when absent
-	assert.Equal(t, "world", parsed.Environment.Applications[1].Proto)
+	assert.Equal(t, map[string]any{"name": "world", "proto": "world"}, apps[1])
 }
 
-// TestWriteKclAppDataFile verifies the generated data-values bridge file content.
-func TestWriteKclAppDataFile(t *testing.T) {
+// TestWriteKclDataFiles verifies the split of a resolved config unit into the generated
+// schema-extension and plain data-values bridge files.
+func TestWriteKclDataFiles(t *testing.T) {
 	t.Parallel()
-	path := filepath.Join(t.TempDir(), "app-data.kcl-generated.ytt.yaml")
-	appConfig := map[string]any{
-		"proto":       "hello",
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "schema.ytt.yaml")
+	valuesPath := filepath.Join(dir, "values.ytt.yaml")
+	values := map[string]any{
 		"application": map[string]any{"greeting": "hi"},
+		"helm":        map[string]any{"charts": []any{map[string]any{"name": "c1", "releaseName": "r1"}}},
 	}
-	require.NoError(t, writeKclAppDataFile(path, appConfig))
+	require.NoError(t, writeKclDataFiles(schemaPath, valuesPath, values))
 
-	content, err := os.ReadFile(path) // #nosec G304 -- test-controlled path
+	schemaContent, err := os.ReadFile(schemaPath) // #nosec G304 -- test-controlled path
 	require.NoError(t, err)
-	assert.Contains(t, string(content), "#@data/values-schema")
+	assert.Contains(t, string(schemaContent), "#@data/values-schema")
+	var schemaValues map[string]any
+	require.NoError(t, yaml.Unmarshal(schemaContent, &schemaValues))
+	assert.Equal(t, map[string]any{"greeting": "hi"}, schemaValues["application"])
+	assert.NotContains(t, schemaValues, "helm", "engine-owned scopes belong to the values file")
 
-	var values map[string]any
-	require.NoError(t, yaml.Unmarshal(content, &values))
-	assert.Equal(t, map[string]any{"greeting": "hi"}, values["application"])
-	assert.NotContains(t, values, "proto", "engine-only key must not leak into data values")
-	// the source map is left intact
-	assert.Contains(t, appConfig, "proto")
+	valuesContent, err := os.ReadFile(valuesPath) // #nosec G304 -- test-controlled path
+	require.NoError(t, err)
+	assert.Contains(t, string(valuesContent), "#@data/values")
+	var plainValues map[string]any
+	require.NoError(t, yaml.Unmarshal(valuesContent, &plainValues))
+	assert.Contains(t, plainValues, "helm")
+	assert.NotContains(t, plainValues, "application")
+
+	// re-running with an emptied unit leaves no stale content behind
+	require.NoError(t, writeKclDataFiles(schemaPath, valuesPath, nil))
+	schemaContent, err = os.ReadFile(schemaPath) // #nosec G304 -- test-controlled path
+	require.NoError(t, err)
+	assert.NotContains(t, string(schemaContent), "greeting")
 }
 
 // TestCheckKclSchemaVersion verifies the engine's schema-version compatibility rule.

--- a/internal/myks/plugin_argocd.go
+++ b/internal/myks/plugin_argocd.go
@@ -36,7 +36,7 @@ argocd:
 // Used by both ArgoCD env render and inspect.
 func (e *Environment) argoCDEnvSourceFiles() []string {
 	files := []string{e.getYttLibAPIDir()}
-	files = append(files, e.collectBySubpath(e.cfg.EnvironmentDataFileName)...)
+	files = append(files, e.envDataFiles()...)
 	files = append(files, e.collectBySubpath(filepath.Join(e.cfg.EnvsDir, e.cfg.ArgoCDDataDirName))...)
 	return files
 }


### PR DESCRIPTION
**What**: KCL-mode port of the integration-tests fixture, full render pipeline fed from the frozen tree, and the byte-identical gate harness (roadmap step 3, closes #880).

**Why**: Prove the KCL config layer on a real fixture end to end (vendir sync, helm values merge, ytt overlays, plugins, slice, ArgoCD app + AppProject generation) and establish the migration gate that will also serve as the `myks migrate` converter's test suite.

**How**:
- Frozen-tree entries are materialized as generated ytt bridge files: an env-level pair and a per-app pair, each split into a schema-extension doc (keys unknown to the embedded schema) and a plain data-values doc (engine-owned scopes — plain docs, unlike schema docs, can carry array values such as `helm.charts`). ytt forbids mixing the two doc kinds in one file, hence the pairs.
- KCL environments then run the regular `Environment.Init` on top of the generated files, so legacy semantics (embedded schema defaults, env data lib, ArgoCD enablement, application roster) apply unchanged; env-level ArgoCD rendering now works in KCL mode.
- `examples/kcl-integration-tests` is the legacy fixture with all data-values authoring replaced by a KCL tree (root level + leaf with derivations, e.g. `envId` derived from the environment id); prototypes, overlays and helm values templates are byte-identical copies.
- `TestKclGate` renders both fixtures and diffs `rendered/` byte-for-byte, with per-app waivers for intentional derivation changes and normalization of the repo-path prefix baked into ArgoCD source paths (the only legitimate difference between the two checkouts).

**Notes for reviewer**:
- Env-level ArgoCD enablement in KCL mode changed from opt-in to the legacy schema default (enabled) — required for parity; the skeleton example already sets it explicitly.
- The legacy fixture's `finalizers: []` no-op (ytt ignores empty arrays in data-values docs) is reproduced bug-for-bug; noted in the port's `envs/env.k`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)